### PR TITLE
Migrate from master and slave words

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,8 +55,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/nova/api/openstack/compute/contrib/agents.py
+++ b/nova/api/openstack/compute/contrib/agents.py
@@ -72,7 +72,6 @@ class AgentController(object):
         agents = []
         if 'hypervisor' in req.GET:
             hypervisor = req.GET['hypervisor']
-
         for agent_build in db.agent_build_get_all(context, hypervisor):
             agents.append({'hypervisor': agent_build.hypervisor,
                            'os': agent_build.os,

--- a/nova/api/openstack/compute/contrib/extended_ips.py
+++ b/nova/api/openstack/compute/contrib/extended_ips.py
@@ -47,7 +47,7 @@ class ExtendedIpsController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -59,7 +59,7 @@ class ExtendedIpsController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -96,7 +96,7 @@ class ExtendedIpsServerTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('server', selector='server')
         xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips.alias: Extended_ips.namespace})
 
 
@@ -105,5 +105,5 @@ class ExtendedIpsServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips.alias: Extended_ips.namespace})

--- a/nova/api/openstack/compute/contrib/extended_ips_mac.py
+++ b/nova/api/openstack/compute/contrib/extended_ips_mac.py
@@ -45,7 +45,7 @@ class ExtendedIpsMacController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsMacServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -57,7 +57,7 @@ class ExtendedIpsMacController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedIpsMacServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -93,7 +93,7 @@ class ExtendedIpsMacServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips_mac.alias: Extended_ips_mac.namespace})
 
 
@@ -102,5 +102,5 @@ class ExtendedIpsMacServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_ips_mac.alias: Extended_ips_mac.namespace})

--- a/nova/api/openstack/compute/contrib/extended_server_attributes.py
+++ b/nova/api/openstack/compute/contrib/extended_server_attributes.py
@@ -39,7 +39,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributeTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -51,7 +51,7 @@ class ExtendedServerAttributesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedServerAttributesTemplate())
 
             servers = list(resp_obj.obj['servers'])
@@ -92,7 +92,7 @@ class ExtendedServerAttributeTemplate(xmlutil.TemplateBuilder):
         make_server(root)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
@@ -102,4 +102,4 @@ class ExtendedServerAttributesTemplate(xmlutil.TemplateBuilder):
         make_server(elem)
         alias = Extended_server_attributes.alias
         namespace = Extended_server_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})

--- a/nova/api/openstack/compute/contrib/extended_status.py
+++ b/nova/api/openstack/compute/contrib/extended_status.py
@@ -36,7 +36,7 @@ class ExtendedStatusController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -48,7 +48,7 @@ class ExtendedStatusController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedStatusesTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -86,7 +86,7 @@ class ExtendedStatusTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})
 
 
@@ -95,5 +95,5 @@ class ExtendedStatusesTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_status.alias: Extended_status.namespace})

--- a/nova/api/openstack/compute/contrib/extended_virtual_interfaces_net.py
+++ b/nova/api/openstack/compute/contrib/extended_virtual_interfaces_net.py
@@ -33,7 +33,7 @@ class ExtendedVirtualInterfaceNetTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'virtual_interface',
                                           selector='virtual_interfaces')
         make_vif(elem)
-        return xmlutil.SlaveTemplate(root, 1,
+        return xmlutil.SubordinateTemplate(root, 1,
                              nsmap={Extended_virtual_interfaces_net.alias:
                                     Extended_virtual_interfaces_net.namespace})
 
@@ -48,7 +48,7 @@ class ExtendedServerVIFNetController(wsgi.Controller):
         key = "%s:net_id" % Extended_virtual_interfaces_net.alias
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVirtualInterfaceNetTemplate())
             for vif in resp_obj.obj['virtual_interfaces']:
                 vif1 = self.network_api.get_vif_by_mac_address(context,

--- a/nova/api/openstack/compute/contrib/extended_volumes.py
+++ b/nova/api/openstack/compute/contrib/extended_volumes.py
@@ -39,7 +39,7 @@ class ExtendedVolumesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVolumesServerTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -51,7 +51,7 @@ class ExtendedVolumesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedVolumesServersTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -90,7 +90,7 @@ class ExtendedVolumesServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_volumes.alias: Extended_volumes.namespace})
 
 
@@ -99,5 +99,5 @@ class ExtendedVolumesServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Extended_volumes.alias: Extended_volumes.namespace})

--- a/nova/api/openstack/compute/contrib/flavor_access.py
+++ b/nova/api/openstack/compute/contrib/flavor_access.py
@@ -46,7 +46,7 @@ class FlavorTemplate(xmlutil.TemplateBuilder):
         make_flavor(root)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorsTemplate(xmlutil.TemplateBuilder):
@@ -56,7 +56,7 @@ class FlavorsTemplate(xmlutil.TemplateBuilder):
         make_flavor(elem)
         alias = Flavor_access.alias
         namespace = Flavor_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class FlavorAccessTemplate(xmlutil.TemplateBuilder):
@@ -65,7 +65,7 @@ class FlavorAccessTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'access',
                                           selector='flavor_access')
         make_flavor_access(elem)
-        return xmlutil.MasterTemplate(root, 1)
+        return xmlutil.MainTemplate(root, 1)
 
 
 def _marshall_flavor_access(flavor):
@@ -127,7 +127,7 @@ class FlavorActionController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorTemplate())
             db_flavor = req.get_db_flavor(id)
 
@@ -137,7 +137,7 @@ class FlavorActionController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorsTemplate())
 
             flavors = list(resp_obj.obj['flavors'])
@@ -149,7 +149,7 @@ class FlavorActionController(wsgi.Controller):
     def create(self, req, body, resp_obj):
         context = req.environ['nova.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=FlavorTemplate())
 
             db_flavor = req.get_db_flavor(resp_obj.obj['flavor']['id'])

--- a/nova/api/openstack/compute/contrib/geo_tags.py
+++ b/nova/api/openstack/compute/contrib/geo_tags.py
@@ -1,0 +1,164 @@
+
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""The GeoTag API extension."""
+from webob import exc
+
+from nova.api.openstack import extensions
+from nova.compute import api as compute_api
+from nova import exception
+from nova.openstack.common.gettextutils import _
+from nova.openstack.common import log as logging
+
+LOG = logging.getLogger(__name__)
+#(licostan): change to right policy and add it to policy file
+authorize = extensions.extension_authorizer('compute', 'services')
+
+
+def _get_context(req):
+    return req.environ['nova.context']
+
+
+class GeoTagsController(object):
+    """The GeoTag API controller for the OpenStack API."""
+    def __init__(self):
+        self.api = compute_api.HostAPI()
+        super(GeoTagsController, self).__init__()
+
+    def index(self, req):
+        """Returns all geo tags."""
+        context = _get_context(req)
+        authorize(context)
+        filters = None
+        if 'host' in req.GET:
+            filters = {'host': req.GET['host']}
+        gt = self.api.geo_tags_get_all(context, filters)
+        return {'geo_tags': [g for g in gt.objects]}
+
+    def create(self, req, body):
+        """Creates a geotag
+        """
+        context = _get_context(req)
+        authorize(context)
+
+        if len(body) != 1:
+            raise exc.HTTPBadRequest()
+
+        try:
+            geo_tag = body['geo_tag']
+            compute_name = geo_tag["compute_name"]
+        except KeyError:
+            raise exc.HTTPBadRequest()
+
+        longitude = geo_tag.get('longitude')
+        latitude = geo_tag.get('latitude')
+        state = geo_tag.get('valid_invalid')
+
+        try:
+            gt = self.api.geo_tags_create(context, compute_name, state,
+                                          longitude=longitude,
+                                          latitude=latitude)
+        except exception.GeoTagExists as e:
+            LOG.info(e)
+            raise exc.HTTPConflict()
+        except exception.ComputeHostNotFound as e:
+            msg = _('Host %(host)s do not exists') % {'host': compute_name}
+            LOG.info(msg)
+            raise exc.HTTPNotFound(explanation=e.format_message())
+
+        return {'geo_tag': gt}
+
+    def show(self, req, id):
+        """Shows the details of an aggregate, hosts and metadata included."""
+        context = _get_context(req)
+        authorize(context)
+        try:
+            geo_tag = self.api.geo_tag_get_by_id_or_node_name(context, id)
+        except exception.NotFound:
+            LOG.info(_("Cannot show geo_tag: %s"), id)
+            raise exc.HTTPNotFound()
+        return {'geo_tag': geo_tag}
+
+    def update(self, req, id, body):
+        """Update geotag by server_name right now.
+           id  == server_name
+        """
+        context = _get_context(req)
+        authorize(context)
+        valid_keys = ['longitude', 'latitude', 'valid_invalid']
+
+        if len(body) != 1:
+            raise exc.HTTPBadRequest()
+        try:
+            update_values = body["geo_tag"]
+        except KeyError:
+            raise exc.HTTPBadRequest()
+
+        if len(update_values) < 1:
+            raise exc.HTTPBadRequest()
+        #(licostan): iteraate update_values and check valid_keys if not
+        #throw error
+        longitude = update_values.get('longitude')
+        latitude = update_values.get('latitude')
+        state = update_values.get('valid_invalid')
+         #(licostan): remove compute_name and pass **update_values
+         #to remove args
+        try:
+            geo_tag = self.api.geo_tags_update(context, id,
+                                           valid_invalid=state,
+                                           longitude=longitude,
+                                           latitude=latitude)
+        except exception.NotFound as e:
+            LOG.info(_('Cannot update geotag'))
+            raise exc.HTTPNotFound(explanation=e.format_message())
+
+        return {'geo_tag': geo_tag}
+
+    def show(self, req, id):
+        """Shows the details of Geo Tags."""
+        context = _get_context(req)
+        authorize(context)
+        try:
+            geo_tag = self.api.geo_tags_get_by_id_or_name(context, id)
+        except exception.NotFound:
+            LOG.info(_("Cannot show GeoTag: %s"), id)
+            raise exc.HTTPNotFound()
+        return {'geo_tag': geo_tag}
+
+    def delete(self, req, id):
+        """Removes a GeoTag by id/servername."""
+        context = _get_context(req)
+        authorize(context)
+        try:
+            self.api.geo_tags_delete(context, id)
+        except exception.NotFound:
+            LOG.info(_('Cannot delete GeoTag: %s'), id)
+            raise exc.HTTPNotFound()
+
+
+class Geo_tags(extensions.ExtensionDescriptor):
+    """Admin-only geo tags administration."""
+
+    name = "Geo Tags"
+    alias = "os-geo-tags"
+    namespace = "http://docs.openstack.org/compute/ext/os-geo-tags/api/v1.1"
+    updated = "2012-01-12T00:00:00+00:00"
+
+    def get_resources(self):
+        resources = []
+        res = extensions.ResourceExtension('os-geo-tags',
+                GeoTagsController())
+        resources.append(res)
+        return resources

--- a/nova/api/openstack/compute/contrib/geo_tags.py
+++ b/nova/api/openstack/compute/contrib/geo_tags.py
@@ -62,8 +62,8 @@ class GeoTagsController(object):
         except KeyError:
             raise exc.HTTPBadRequest()
 
-        longitude = geo_tag.get('longitude')
-        latitude = geo_tag.get('latitude')
+        longitude = geo_tag.get('plt_longitude')
+        latitude = geo_tag.get('plt_latitude')
         state = geo_tag.get('valid_invalid')
 
         try:
@@ -97,7 +97,7 @@ class GeoTagsController(object):
         """
         context = _get_context(req)
         authorize(context)
-        valid_keys = ['longitude', 'latitude', 'valid_invalid']
+        valid_keys = ['plt_longitude', 'plt_latitude', 'valid_invalid']
 
         if len(body) != 1:
             raise exc.HTTPBadRequest()
@@ -110,8 +110,8 @@ class GeoTagsController(object):
             raise exc.HTTPBadRequest()
         #(licostan): iteraate update_values and check valid_keys if not
         #throw error
-        longitude = update_values.get('longitude')
-        latitude = update_values.get('latitude')
+        longitude = update_values.get('plt_longitude')
+        latitude = update_values.get('plt_latitude')
         state = update_values.get('valid_invalid')
          #(licostan): remove compute_name and pass **update_values
          #to remove args

--- a/nova/api/openstack/compute/contrib/geo_tags.py
+++ b/nova/api/openstack/compute/contrib/geo_tags.py
@@ -65,11 +65,12 @@ class GeoTagsController(object):
         longitude = geo_tag.get('plt_longitude')
         latitude = geo_tag.get('plt_latitude')
         state = geo_tag.get('valid_invalid')
-
+        location = geo_tag.get('location')
         try:
             gt = self.api.geo_tags_create(context, compute_name, state,
                                           longitude=longitude,
-                                          latitude=latitude)
+                                          latitude=latitude,
+                                          location=location)
         except exception.GeoTagExists as e:
             LOG.info(e)
             raise exc.HTTPConflict()
@@ -97,7 +98,8 @@ class GeoTagsController(object):
         """
         context = _get_context(req)
         authorize(context)
-        valid_keys = ['plt_longitude', 'plt_latitude', 'valid_invalid']
+        valid_keys = ['plt_longitude', 'plt_latitude', 'valid_invalid',
+                      'location']
 
         if len(body) != 1:
             raise exc.HTTPBadRequest()
@@ -113,13 +115,15 @@ class GeoTagsController(object):
         longitude = update_values.get('plt_longitude')
         latitude = update_values.get('plt_latitude')
         state = update_values.get('valid_invalid')
+        location = update_values.get('location')
          #(licostan): remove compute_name and pass **update_values
          #to remove args
         try:
             geo_tag = self.api.geo_tags_update(context, id,
                                            valid_invalid=state,
                                            longitude=longitude,
-                                           latitude=latitude)
+                                           latitude=latitude,
+                                           location=location)
         except exception.NotFound as e:
             LOG.info(_('Cannot update geotag'))
             raise exc.HTTPNotFound(explanation=e.format_message())

--- a/nova/api/openstack/compute/contrib/image_size.py
+++ b/nova/api/openstack/compute/contrib/image_size.py
@@ -29,7 +29,7 @@ class ImagesSizeTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('images')
         elem = xmlutil.SubTemplateElement(root, 'image', selector='images')
         make_image(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Image_size.alias: Image_size.namespace})
 
 
@@ -37,7 +37,7 @@ class ImageSizeTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('image', selector='image')
         make_image(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Image_size.alias: Image_size.namespace})
 
 
@@ -51,7 +51,7 @@ class ImageSizeController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ["nova.context"]
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ImageSizeTemplate())
             image_resp = resp_obj.obj['image']
             # image guaranteed to be in the cache due to the core API adding
@@ -63,7 +63,7 @@ class ImageSizeController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ImagesSizeTemplate())
             images_resp = list(resp_obj.obj['images'])
             # images guaranteed to be in the cache due to the core API adding

--- a/nova/api/openstack/compute/contrib/server_usage.py
+++ b/nova/api/openstack/compute/contrib/server_usage.py
@@ -41,7 +41,7 @@ class ServerUsageController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ServerUsageTemplate())
             server = resp_obj.obj['server']
             db_instance = req.get_db_instance(server['id'])
@@ -53,7 +53,7 @@ class ServerUsageController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['nova.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ServerUsagesTemplate())
             servers = list(resp_obj.obj['servers'])
             for server in servers:
@@ -89,7 +89,7 @@ class ServerUsageTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Server_usage.alias: Server_usage.namespace})
 
 
@@ -98,5 +98,5 @@ class ServerUsagesTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
-        return xmlutil.SlaveTemplate(root, 1, nsmap={
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={
             Server_usage.alias: Server_usage.namespace})

--- a/nova/api/openstack/compute/contrib/services.py
+++ b/nova/api/openstack/compute/contrib/services.py
@@ -99,7 +99,7 @@ class ServiceController(object):
         geo_tags = self.host_api.geo_tags_get_all(context, None)
         for x in services:
             if x['binary'] == 'nova-compute':
-                tags = [gt for gt in geo_tags
+                tags = [gt for gt in geo_tags.objects
                         if gt['server_name'] == x['host']]
                 if len(tags):
                     x.geo_tag = tags[0]

--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -124,7 +124,7 @@ class ServerTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server', selector='server')
         make_server(root, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class MinimalServersTemplate(xmlutil.TemplateBuilder):
@@ -133,7 +133,7 @@ class MinimalServersTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem)
         xmlutil.make_links(root, 'servers_links')
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServersTemplate(xmlutil.TemplateBuilder):
@@ -141,27 +141,27 @@ class ServersTemplate(xmlutil.TemplateBuilder):
         root = xmlutil.TemplateElement('servers')
         elem = xmlutil.SubTemplateElement(root, 'server', selector='servers')
         make_server(elem, detailed=True)
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServerAdminPassTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server')
         root.set('adminPass')
-        return xmlutil.SlaveTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.SubordinateTemplate(root, 1, nsmap=server_nsmap)
 
 
 class ServerMultipleCreateTemplate(xmlutil.TemplateBuilder):
     def construct(self):
         root = xmlutil.TemplateElement('server')
         root.set('reservation_id')
-        return xmlutil.MasterTemplate(root, 1, nsmap=server_nsmap)
+        return xmlutil.MainTemplate(root, 1, nsmap=server_nsmap)
 
 
 def FullServerTemplate():
-    master = ServerTemplate()
-    master.attach(ServerAdminPassTemplate())
-    return master
+    main = ServerTemplate()
+    main.attach(ServerAdminPassTemplate())
+    return main
 
 
 class CommonDeserializer(wsgi.MetadataXMLDeserializer):

--- a/nova/api/openstack/wsgi.py
+++ b/nova/api/openstack/wsgi.py
@@ -593,7 +593,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3254,7 +3254,7 @@ class HostAPI(base.Base):
         return self.db.compute_node_statistics(context)
 
     def geo_tags_get_all(self, context, filters):
-        """Returns a list of GeoTags"""
+        """Returns a list of GeoTags."""
 
         if filters is None:
             filters = {}
@@ -3263,8 +3263,8 @@ class HostAPI(base.Base):
         return gtags
 
     def geo_tags_create(self, context, compute_name, valid_invalid,
-                        longitude, latitude):
-        """Returns a list of GeoTags"""
+                        longitude, latitude, location=None):
+        """Returns a list of GeoTags."""
         self._assert_host_exists(context, compute_name)
 
         geo_tags = geo_tags_obj.GeoTag()
@@ -3272,13 +3272,15 @@ class HostAPI(base.Base):
         geo_tags.plt_longitude = longitude
         geo_tags.plt_latitude = latitude
         geo_tags.server_name = compute_name
+        geo_tags.loc_or_error_msg = location
         geo_tags.create(context)
 
         return geo_tags
 
     def geo_tags_update(self, context, geo_tag_id,
-                        valid_invalid, longitude, latitude):
-        """Returns a list of GeoTags"""
+                        valid_invalid, longitude=None, latitude=None,
+                        location=None):
+        """Returns a list of GeoTags."""
         #(licostan): create a get_by_node_name_or_id ()... to replace both
         #lines
         geo_tag = geo_tags_obj.GeoTag.get_by_node_name(context, geo_tag_id)
@@ -3289,22 +3291,26 @@ class HostAPI(base.Base):
             raise exception.NotFound()
 
         geo_tag.valid_invalid = valid_invalid
-        geo_tag.plt_longitude = longitude
-        geo_tag.plt_latitude = latitude
+        if longitude:
+            geo_tag.plt_longitude = longitude
+        if latitude:
+            geo_tag.plt_latitude = latitude
+        if location:
+            geo_tag.loc_or_error_msg = location
         geo_tag.save()
         return geo_tag
 
     def geo_tags_delete(self, context, geo_tag_id):
-        """Delete GeoTags"""
-        geo_tag = geo_tags_obj.GeoTag.get_by_id_or_node_name(context, geo_tag_id)
+        """Delete GeoTags."""
+        geo_tag = geo_tags_obj.GeoTag.get_by_id_or_node_name(context,
+                                                             geo_tag_id)
         if not geo_tag:
             raise exception.NotFound()
-        
         geo_tag.destroy()
-    
+
     def geo_tags_get_by_id_or_name(self, context, geo_tag_id):
         return geo_tags_obj.GeoTag.get_by_id_or_node_name(context, geo_tag_id)
-    
+
 
 class InstanceActionAPI(base.Base):
     """Sub-set of the Compute Manager API for managing instance actions."""

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3273,6 +3273,7 @@ class HostAPI(base.Base):
         geo_tags.plt_latitude = latitude
         geo_tags.server_name = compute_name
         geo_tags.create(context)
+        
         return geo_tags
 
     def geo_tags_update(self, context, geo_tag_id,

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3273,7 +3273,7 @@ class HostAPI(base.Base):
         geo_tags.plt_latitude = latitude
         geo_tags.server_name = compute_name
         geo_tags.create(context)
-        
+
         return geo_tags
 
     def geo_tags_update(self, context, geo_tag_id,
@@ -3284,10 +3284,10 @@ class HostAPI(base.Base):
         geo_tag = geo_tags_obj.GeoTag.get_by_node_name(context, geo_tag_id)
         if not geo_tag:
             geo_tag = geo_tags_obj.GeoTag.get_by_id(context, geo_tag_id)
-        
+
         if not geo_tag:
             raise exception.NotFound()
-        
+
         geo_tag.valid_invalid = valid_invalid
         geo_tag.plt_longitude = longitude
         geo_tag.plt_latitude = latitude

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -3309,7 +3309,11 @@ class HostAPI(base.Base):
         geo_tag.destroy()
 
     def geo_tags_get_by_id_or_name(self, context, geo_tag_id):
-        return geo_tags_obj.GeoTag.get_by_id_or_node_name(context, geo_tag_id)
+        geo_tag = geo_tags_obj.GeoTag.get_by_id_or_node_name(context,
+                                                             geo_tag_id)
+        if not geo_tag:
+            raise exception.NotFound()
+        return geo_tag
 
 
 class InstanceActionAPI(base.Base):

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -661,7 +661,7 @@ class ComputeManager(manager.Manager):
             driver_uuids = self.driver.list_instance_uuids()
             filters['uuid'] = driver_uuids
             local_instances = instance_obj.InstanceList.get_by_filters(
-                context, filters, use_slave=True)
+                context, filters, use_subordinate=True)
             return local_instances
         except NotImplementedError:
             pass
@@ -670,7 +670,7 @@ class ComputeManager(manager.Manager):
         # to brute force.
         driver_instances = self.driver.list_instances()
         instances = instance_obj.InstanceList.get_by_filters(context, filters,
-                                                             use_slave=True)
+                                                             use_subordinate=True)
         name_map = dict((instance.name, instance) for instance in instances)
         local_instances = []
         for driver_instance in driver_instances:
@@ -1102,7 +1102,7 @@ class ComputeManager(manager.Manager):
         """This call passes straight through to the virtualization driver."""
         return self.driver.refresh_provider_fw_rules()
 
-    def _get_instance_nw_info(self, context, instance, use_slave=False):
+    def _get_instance_nw_info(self, context, instance, use_subordinate=False):
         """Get a list of dictionaries of network data of an instance."""
         if (not hasattr(instance, 'system_metadata') or
                 len(instance['system_metadata']) == 0):
@@ -1113,7 +1113,7 @@ class ComputeManager(manager.Manager):
             # succeed.
             instance = instance_obj.Instance.get_by_uuid(context,
                                                          instance['uuid'],
-                                                         use_slave=use_slave)
+                                                         use_subordinate=use_subordinate)
 
         network_info = self.network_api.get_instance_nw_info(context,
                                                              instance)
@@ -1463,7 +1463,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
 
         building_insts = instance_obj.InstanceList.get_by_filters(context,
-                           filters, expected_attrs=[], use_slave=True)
+                           filters, expected_attrs=[], use_subordinate=True)
 
         for instance in building_insts:
             if timeutils.is_older_than(instance['created_at'], timeout):
@@ -4826,7 +4826,7 @@ class ComputeManager(manager.Manager):
             # The list of instances to heal is empty so rebuild it
             LOG.debug(_('Rebuilding the list of instances to heal'))
             db_instances = instance_obj.InstanceList.get_by_host(
-                context, self.host, expected_attrs=[], use_slave=True)
+                context, self.host, expected_attrs=[], use_subordinate=True)
             for inst in db_instances:
                 # We don't want to refersh the cache for instances
                 # which are building or deleting so don't put them
@@ -4856,7 +4856,7 @@ class ComputeManager(manager.Manager):
                     inst = instance_obj.Instance.get_by_uuid(
                             context, instance_uuids.pop(0),
                             expected_attrs=['system_metadata'],
-                            use_slave=True)
+                            use_subordinate=True)
                 except exception.InstanceNotFound:
                     # Instance is gone.  Try to grab another.
                     continue
@@ -4879,7 +4879,7 @@ class ComputeManager(manager.Manager):
             try:
                 # Call to network API to get instance info.. this will
                 # force an update to the instance's info_cache
-                self._get_instance_nw_info(context, instance, use_slave=True)
+                self._get_instance_nw_info(context, instance, use_subordinate=True)
                 LOG.debug(_('Updated the network info_cache for instance'),
                           instance=instance)
             except Exception:
@@ -4895,7 +4895,7 @@ class ComputeManager(manager.Manager):
             filters = {'task_state': task_states.REBOOTING,
                        'host': self.host}
             rebooting = instance_obj.InstanceList.get_by_filters(
-                context, filters, expected_attrs=[], use_slave=True)
+                context, filters, expected_attrs=[], use_subordinate=True)
 
             to_poll = []
             for instance in rebooting:
@@ -4912,7 +4912,7 @@ class ComputeManager(manager.Manager):
                        'host': self.host}
             rescued_instances = self.conductor_api.instance_get_all_by_filters(
                 context, filters, columns_to_join=["system_metadata"],
-                use_slave=True)
+                use_subordinate=True)
 
             to_unrescue = []
             for instance in rescued_instances:
@@ -4931,7 +4931,7 @@ class ComputeManager(manager.Manager):
         mig_list_cls = migration_obj.MigrationList
         migrations = mig_list_cls.get_unconfirmed_by_dest_compute(
                 context, CONF.resize_confirm_window, self.host,
-                use_slave=True)
+                use_subordinate=True)
 
         migrations_info = dict(migration_count=len(migrations),
                 confirm_window=CONF.resize_confirm_window)
@@ -4959,7 +4959,7 @@ class ComputeManager(manager.Manager):
             try:
                 instance = instance_obj.Instance.get_by_uuid(context,
                             instance_uuid, expected_attrs=expected_attrs,
-                            use_slave=True)
+                            use_subordinate=True)
             except exception.InstanceNotFound:
                 reason = (_("Instance %s not found") %
                           instance_uuid)
@@ -4996,7 +4996,7 @@ class ComputeManager(manager.Manager):
                    'host': self.host}
         shelved_instances = instance_obj.InstanceList.get_by_filters(
             context, filters=filters, expected_attrs=['system_metadata'],
-            use_slave=True)
+            use_subordinate=True)
 
         to_gc = []
         for instance in shelved_instances:
@@ -5091,7 +5091,7 @@ class ComputeManager(manager.Manager):
 
             instances = instance_obj.InstanceList.get_by_host(context,
                                                               self.host,
-                                                              use_slave=True)
+                                                              use_subordinate=True)
             try:
                 bw_counters = self.driver.get_all_bw_counters(instances)
             except NotImplementedError:
@@ -5114,7 +5114,7 @@ class ComputeManager(manager.Manager):
                 last_ctr_in = None
                 last_ctr_out = None
                 # TODO(geekinutah): Once bw_usage_cache object is created
-                #                   need to revisit this and slaveify.
+                #                   need to revisit this and subordinateify.
                 usage = self.conductor_api.bw_usage_get(context,
                                                         bw_ctr['uuid'],
                                                         start_time,
@@ -5125,7 +5125,7 @@ class ComputeManager(manager.Manager):
                     last_ctr_in = usage['last_ctr_in']
                     last_ctr_out = usage['last_ctr_out']
                 else:
-                    # TODO(geekinutah): Same here, pls slaveify
+                    # TODO(geekinutah): Same here, pls subordinateify
                     usage = self.conductor_api.bw_usage_get(
                         context, bw_ctr['uuid'], prev_time,
                         bw_ctr['mac_address'])
@@ -5218,7 +5218,7 @@ class ComputeManager(manager.Manager):
         """
         db_instances = instance_obj.InstanceList.get_by_host(context,
                                                              self.host,
-                                                             use_slave=True)
+                                                             use_subordinate=True)
 
         num_vm_instances = self.driver.get_num_instances()
         num_db_instances = len(db_instances)
@@ -5247,7 +5247,7 @@ class ComputeManager(manager.Manager):
                     self._sync_instance_power_state(context,
                                                     db_instance,
                                                     vm_power_state,
-                                                    use_slave=True)
+                                                    use_subordinate=True)
                 except exception.InstanceNotFound:
                     # NOTE(hanlind): If the instance gets deleted during sync,
                     # silently ignore and move on to next instance.
@@ -5258,7 +5258,7 @@ class ComputeManager(manager.Manager):
                                 instance=db_instance)
 
     def _sync_instance_power_state(self, context, db_instance, vm_power_state,
-                                   use_slave=False):
+                                   use_subordinate=False):
         """Align instance power state between the database and hypervisor.
 
         If the instance is not found on the hypervisor, but is in the database,
@@ -5267,7 +5267,7 @@ class ComputeManager(manager.Manager):
 
         # We re-query the DB to get the latest instance info to minimize
         # (not eliminate) race condition.
-        db_instance.refresh(use_slave=use_slave)
+        db_instance.refresh(use_subordinate=use_subordinate)
         db_power_state = db_instance.power_state
         vm_state = db_instance.vm_state
 
@@ -5404,7 +5404,7 @@ class ComputeManager(manager.Manager):
         instances = instance_obj.InstanceList.get_by_filters(
             context, filters,
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True)
+            use_subordinate=True)
         for instance in instances:
             if self._deleted_old_enough(instance, interval):
                 bdms = (block_device_obj.BlockDeviceMappingList.
@@ -5490,7 +5490,7 @@ class ComputeManager(manager.Manager):
             for instance in self._running_deleted_instances(context):
                 bdms = (block_device_obj.BlockDeviceMappingList.
                         get_by_instance_uuid(context, instance.uuid,
-                                             use_slave=True))
+                                             use_subordinate=True))
 
                 if action == "log":
                     LOG.warning(_("Detected instance with name label "
@@ -5585,11 +5585,11 @@ class ComputeManager(manager.Manager):
 
     @aggregate_object_compat
     @wrap_exception()
-    def add_aggregate_host(self, context, aggregate, host, slave_info):
+    def add_aggregate_host(self, context, aggregate, host, subordinate_info):
         """Notify hypervisor of change (for hypervisor pools)."""
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug(_('Hypervisor driver does not support '
                         'add_aggregate_host'))
@@ -5602,11 +5602,11 @@ class ComputeManager(manager.Manager):
 
     @aggregate_object_compat
     @wrap_exception()
-    def remove_aggregate_host(self, context, host, slave_info, aggregate):
+    def remove_aggregate_host(self, context, host, subordinate_info, aggregate):
         """Removes a host from a physical hypervisor pool."""
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug(_('Hypervisor driver does not support '
                         'remove_aggregate_host'))
@@ -5663,7 +5663,7 @@ class ComputeManager(manager.Manager):
                    'soft_deleted': True,
                    'host': nodes}
         filtered_instances = instance_obj.InstanceList.get_by_filters(context,
-                                 filters, expected_attrs=[], use_slave=True)
+                                 filters, expected_attrs=[], use_subordinate=True)
 
         self.driver.manage_image_cache(context, filtered_instances)
 

--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -141,7 +141,7 @@ class ComputeAPI(object):
 
         2.0 - Remove 1.x backwards compat
         2.1 - Adds orig_sys_metadata to rebuild_instance()
-        2.2 - Adds slave_info parameter to add_aggregate_host() and
+        2.2 - Adds subordinate_info parameter to add_aggregate_host() and
               remove_aggregate_host()
         2.3 - Adds volume_id to reserve_block_device_name()
         2.4 - Add bdms to terminate_instance
@@ -272,7 +272,7 @@ class ComputeAPI(object):
         return current
 
     def add_aggregate_host(self, ctxt, aggregate, host_param, host,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -293,7 +293,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         if self.client.can_send_version('3.12'):
@@ -643,7 +643,7 @@ class ComputeAPI(object):
         cctxt.cast(ctxt, 'refresh_provider_fw_rules')
 
     def remove_aggregate_host(self, ctxt, aggregate, host_param, host,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -664,7 +664,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         if self.client.can_send_version('3.13'):

--- a/nova/conductor/api.py
+++ b/nova/conductor/api.py
@@ -84,13 +84,13 @@ class LocalAPI(object):
     def instance_get_all_by_filters(self, context, filters,
                                     sort_key='created_at',
                                     sort_dir='desc',
-                                    columns_to_join=None, use_slave=False):
+                                    columns_to_join=None, use_subordinate=False):
         return self._manager.instance_get_all_by_filters(context,
                                                          filters,
                                                          sort_key,
                                                          sort_dir,
                                                          columns_to_join,
-                                                         use_slave)
+                                                         use_subordinate)
 
     def instance_get_active_by_window_joined(self, context, begin, end=None,
                                              project_id=None, host=None):

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -354,10 +354,10 @@ class ConductorManager(manager.Manager):
 
     def instance_get_all_by_filters(self, context, filters, sort_key,
                                     sort_dir, columns_to_join=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         result = self.db.instance_get_all_by_filters(
             context, filters, sort_key, sort_dir,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
         return jsonutils.to_primitive(result)
 
     # NOTE(hanlind): This method can be removed in v2.0 of the RPC API.
@@ -925,9 +925,9 @@ class _ConductorManagerV2Proxy(object):
                 instance, legacy)
 
     def instance_get_all_by_filters(self, context, filters, sort_key,
-                                    sort_dir, columns_to_join, use_slave):
+                                    sort_dir, columns_to_join, use_subordinate):
         return self.manager.instance_get_all_by_filters(context, filters,
-                sort_key, sort_dir, columns_to_join, use_slave)
+                sort_key, sort_dir, columns_to_join, use_subordinate)
 
     def instance_get_active_by_window_joined(self, context, begin, end,
                                              project_id, host):

--- a/nova/conductor/rpcapi.py
+++ b/nova/conductor/rpcapi.py
@@ -124,7 +124,7 @@ class ConductorAPI(object):
     1.62 - Added object_backport()
     1.63 - Changed the format of values['stats'] from a dict to a JSON string
            in compute_node_update()
-    1.64 - Added use_slave to instance_get_all_filters()
+    1.64 - Added use_subordinate to instance_get_all_filters()
     ...  - Remove instance_type_get()
     ...  - Remove aggregate_get()
     ...  - Remove aggregate_get_by_host()
@@ -232,10 +232,10 @@ class ConductorAPI(object):
 
     def instance_get_all_by_filters(self, context, filters, sort_key,
                                     sort_dir, columns_to_join=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         msg_kwargs = dict(filters=filters, sort_key=sort_key,
                           sort_dir=sort_dir, columns_to_join=columns_to_join,
-                          use_slave=use_slave)
+                          use_subordinate=use_subordinate)
         cctxt = self.client.prepare()
         return cctxt.call(context, 'instance_get_all_by_filters', **msg_kwargs)
 

--- a/nova/console/xvp.py
+++ b/nova/console/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
                help='Generated XVP conf file'),
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                help='XVP log file'),

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -446,12 +446,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-        dest_compute, use_slave=False):
+        dest_compute, use_subordinate=False):
     """Finds all unconfirmed migrations within the confirmation window for
     a specific destination compute host.
     """
     return IMPL.migration_get_unconfirmed_by_dest_compute(context,
-            confirm_window, dest_compute, use_slave=use_slave)
+            confirm_window, dest_compute, use_subordinate=use_subordinate)
 
 
 def migration_get_in_progress_by_host_and_node(context, host, node):
@@ -588,10 +588,10 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
     return IMPL.virtual_interface_get_by_uuid(context, vif_uuid)
 
 
-def virtual_interface_get_by_instance(context, instance_id, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_id, use_subordinate=False):
     """Gets all virtual_interfaces for instance."""
     return IMPL.virtual_interface_get_by_instance(context, instance_id,
-                                                  use_slave=use_slave)
+                                                  use_subordinate=use_subordinate)
 
 
 def virtual_interface_get_by_instance_and_network(context, instance_id,
@@ -632,10 +632,10 @@ def instance_destroy(context, instance_uuid, constraint=None,
     return rv
 
 
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     """Get an instance or raise if it does not exist."""
     return IMPL.instance_get_by_uuid(context, uuid,
-                                     columns_to_join, use_slave=use_slave)
+                                     columns_to_join, use_subordinate=use_subordinate)
 
 
 def instance_get(context, instance_id, columns_to_join=None):
@@ -651,13 +651,13 @@ def instance_get_all(context, columns_to_join=None):
 
 def instance_get_all_by_filters(context, filters, sort_key='created_at',
                                 sort_dir='desc', limit=None, marker=None,
-                                columns_to_join=None, use_slave=False):
+                                columns_to_join=None, use_subordinate=False):
     """Get all instances that match all filters."""
     return IMPL.instance_get_all_by_filters(context, filters, sort_key,
                                             sort_dir, limit=limit,
                                             marker=marker,
                                             columns_to_join=columns_to_join,
-                                            use_slave=use_slave)
+                                            use_subordinate=use_subordinate)
 
 
 def instance_get_active_by_window_joined(context, begin, end=None,
@@ -672,11 +672,11 @@ def instance_get_active_by_window_joined(context, begin, end=None,
 
 
 def instance_get_all_by_host(context, host,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
     """Get all instances belonging to a host."""
     return IMPL.instance_get_all_by_host(context, host,
                                          columns_to_join,
-                                         use_slave=use_slave)
+                                         use_subordinate=use_subordinate)
 
 
 def instance_get_all_by_host_and_node(context, host, node):
@@ -1184,11 +1184,11 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
+                                             use_subordinate=False):
     """Get all block device mapping belonging to an instance."""
     return IMPL.block_device_mapping_get_all_by_instance(context,
                                                          instance_uuid,
-                                                         use_slave)
+                                                         use_subordinate)
 
 
 def block_device_mapping_get_by_volume_id(context, volume_id,
@@ -1620,7 +1620,7 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     """Return bw usage for instance and mac in a given audit period."""
     return IMPL.bw_usage_get(context, uuid, start_period, mac)
 

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -1923,3 +1923,34 @@ def archive_deleted_rows_for_table(context, tablename, max_rows=None):
     """
     return IMPL.archive_deleted_rows_for_table(context, tablename,
                                                max_rows=max_rows)
+
+                                               
+#########################
+def geo_tag_destroy(context, geo_tag_id):
+    """Delete GeoTag."""
+    return IMPL.geo_tag_destroy(context, geo_tag_id)
+
+def geo_tag_get_by_node_name(context, node_name):
+    """Get GeoTag by host node name."""
+    return IMPL.geo_tag_get_by_node_name(context, node_name)
+
+def geo_tag_get_by_id(context, gt_id):
+    """Get GeoTag by id."""
+    return IMPL.geo_tag_get_by_id(context, gt_id)
+
+
+def geo_tag_get_all(context, filters):
+    """Get GeoTags."""
+    return IMPL.geo_tag_get_all(context, filters)
+
+def geo_tag_create(context, values):
+    """Create GeoTag."""
+    return IMPL.geo_tag_create(context, values)
+
+def geo_tag_update(context, geo_tag_id, values):
+    """Update GeoTag."""
+    return IMPL.geo_tag_update(context, geo_tag_id, values)
+
+def geo_tag_get_by_id_or_node_name(context, geo_tag_id):
+    """Get GeoTag."""
+    return IMPL.geo_tag_get_by_id_or_node_name(context, geo_tag_id)

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -1924,15 +1924,17 @@ def archive_deleted_rows_for_table(context, tablename, max_rows=None):
     return IMPL.archive_deleted_rows_for_table(context, tablename,
                                                max_rows=max_rows)
 
-                                               
+
 #########################
 def geo_tag_destroy(context, geo_tag_id):
     """Delete GeoTag."""
     return IMPL.geo_tag_destroy(context, geo_tag_id)
 
+
 def geo_tag_get_by_node_name(context, node_name):
     """Get GeoTag by host node name."""
     return IMPL.geo_tag_get_by_node_name(context, node_name)
+
 
 def geo_tag_get_by_id(context, gt_id):
     """Get GeoTag by id."""
@@ -1943,14 +1945,22 @@ def geo_tag_get_all(context, filters):
     """Get GeoTags."""
     return IMPL.geo_tag_get_all(context, filters)
 
+
 def geo_tag_create(context, values):
     """Create GeoTag."""
     return IMPL.geo_tag_create(context, values)
+
 
 def geo_tag_update(context, geo_tag_id, values):
     """Update GeoTag."""
     return IMPL.geo_tag_update(context, geo_tag_id, values)
 
+
 def geo_tag_get_by_id_or_node_name(context, geo_tag_id):
     """Get GeoTag."""
     return IMPL.geo_tag_get_by_id_or_node_name(context, geo_tag_id)
+
+
+def geo_tag_get_all_by_filters(context, filters):
+    """Finds all GeoTag by filters."""
+    return IMPL.geo_tag_get_all_by_filters(context, filters)

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -71,10 +71,10 @@ db_opts = [
 ]
 
 connection_opts = [
-    cfg.StrOpt('slave_connection',
+    cfg.StrOpt('subordinate_connection',
                secret=True,
                help='The SQLAlchemy connection string used to connect to the '
-                    'slave database'),
+                    'subordinate database'),
 ]
 
 CONF = cfg.CONF
@@ -92,12 +92,12 @@ _MASTER_FACADE = None
 _SLAVE_FACADE = None
 
 
-def _create_facade_lazily(use_slave=False):
+def _create_facade_lazily(use_subordinate=False):
     global _MASTER_FACADE
     global _SLAVE_FACADE
 
-    return_slave = use_slave and CONF.database.slave_connection
-    if not return_slave:
+    return_subordinate = use_subordinate and CONF.database.subordinate_connection
+    if not return_subordinate:
         if _MASTER_FACADE is None:
             _MASTER_FACADE = db_session.EngineFacade(
                 CONF.database.connection,
@@ -107,19 +107,19 @@ def _create_facade_lazily(use_slave=False):
     else:
         if _SLAVE_FACADE is None:
             _SLAVE_FACADE = db_session.EngineFacade(
-                CONF.database.slave_connection,
+                CONF.database.subordinate_connection,
                 **dict(CONF.database.iteritems())
             )
         return _SLAVE_FACADE
 
 
-def get_engine(use_slave=False):
-    facade = _create_facade_lazily(use_slave)
+def get_engine(use_subordinate=False):
+    facade = _create_facade_lazily(use_subordinate)
     return facade.get_engine()
 
 
-def get_session(use_slave=False, **kwargs):
-    facade = _create_facade_lazily(use_slave)
+def get_session(use_subordinate=False, **kwargs):
+    facade = _create_facade_lazily(use_subordinate)
     return facade.get_session(**kwargs)
 
 
@@ -215,7 +215,7 @@ def model_query(context, model, *args, **kwargs):
     """Query helper that accounts for context's `read_deleted` field.
 
     :param context: context to query under
-    :param use_slave: If true, use slave_connection
+    :param use_subordinate: If true, use subordinate_connection
     :param session: if present, the session to use
     :param read_deleted: if present, overrides context's read_deleted field.
     :param project_only: if present and context is user-type, then restrict
@@ -227,11 +227,11 @@ def model_query(context, model, *args, **kwargs):
             model parameter.
     """
 
-    use_slave = kwargs.get('use_slave') or False
-    if CONF.database.slave_connection == '':
-        use_slave = False
+    use_subordinate = kwargs.get('use_subordinate') or False
+    if CONF.database.subordinate_connection == '':
+        use_subordinate = False
 
-    session = kwargs.get('session') or get_session(use_slave=use_slave)
+    session = kwargs.get('session') or get_session(use_subordinate=use_subordinate)
     read_deleted = kwargs.get('read_deleted') or context.read_deleted
     project_only = kwargs.get('project_only', False)
 
@@ -1434,9 +1434,9 @@ def virtual_interface_create(context, values):
     return vif_ref
 
 
-def _virtual_interface_query(context, session=None, use_slave=False):
+def _virtual_interface_query(context, session=None, use_subordinate=False):
     return model_query(context, models.VirtualInterface, session=session,
-                       read_deleted="no", use_slave=use_slave)
+                       read_deleted="no", use_subordinate=use_subordinate)
 
 
 @require_context
@@ -1482,12 +1482,12 @@ def virtual_interface_get_by_uuid(context, vif_uuid):
 
 @require_context
 @require_instance_exists_using_uuid
-def virtual_interface_get_by_instance(context, instance_uuid, use_slave=False):
+def virtual_interface_get_by_instance(context, instance_uuid, use_subordinate=False):
     """Gets all virtual interfaces for instance.
 
     :param instance_uuid: = uuid of the instance to retrieve vifs for
     """
-    vif_refs = _virtual_interface_query(context, use_slave=use_slave).\
+    vif_refs = _virtual_interface_query(context, use_subordinate=use_subordinate).\
                        filter_by(instance_uuid=instance_uuid).\
                        all()
     return vif_refs
@@ -1682,16 +1682,16 @@ def instance_destroy(context, instance_uuid, constraint=None):
 
 
 @require_context
-def instance_get_by_uuid(context, uuid, columns_to_join=None, use_slave=False):
+def instance_get_by_uuid(context, uuid, columns_to_join=None, use_subordinate=False):
     return _instance_get_by_uuid(context, uuid,
-            columns_to_join=columns_to_join, use_slave=use_slave)
+            columns_to_join=columns_to_join, use_subordinate=use_subordinate)
 
 
 def _instance_get_by_uuid(context, uuid, session=None,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     result = _build_instance_get(context, session=session,
                                  columns_to_join=columns_to_join,
-                                 use_slave=use_slave).\
+                                 use_subordinate=use_subordinate).\
                 filter_by(uuid=uuid).\
                 first()
 
@@ -1720,9 +1720,9 @@ def instance_get(context, instance_id, columns_to_join=None):
 
 
 def _build_instance_get(context, session=None,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
     query = model_query(context, models.Instance, session=session,
-                        project_only=True, use_slave=use_slave).\
+                        project_only=True, use_subordinate=use_subordinate).\
             options(joinedload_all('security_groups.rules')).\
             options(joinedload('info_cache'))
     if columns_to_join is None:
@@ -1740,7 +1740,7 @@ def _build_instance_get(context, session=None,
 
 
 def _instances_fill_metadata(context, instances,
-                             manual_joins=None, use_slave=False):
+                             manual_joins=None, use_subordinate=False):
     """Selectively fill instances with manually-joined metadata. Note that
     instance will be converted to a dict.
 
@@ -1758,13 +1758,13 @@ def _instances_fill_metadata(context, instances,
     meta = collections.defaultdict(list)
     if 'metadata' in manual_joins:
         for row in _instance_metadata_get_multi(context, uuids,
-                                                use_slave=use_slave):
+                                                use_subordinate=use_subordinate):
             meta[row['instance_uuid']].append(row)
 
     sys_meta = collections.defaultdict(list)
     if 'system_metadata' in manual_joins:
         for row in _instance_system_metadata_get_multi(context, uuids,
-                                                       use_slave=use_slave):
+                                                       use_subordinate=use_subordinate):
             sys_meta[row['instance_uuid']].append(row)
 
     pcidevs = collections.defaultdict(list)
@@ -1816,7 +1816,7 @@ def instance_get_all(context, columns_to_join=None):
 @require_context
 def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
                                 limit=None, marker=None, columns_to_join=None,
-                                use_slave=False):
+                                use_subordinate=False):
     """Return instances that match all filters.  Deleted instances
     will be returned by default, unless there's a filter that says
     otherwise.
@@ -1853,10 +1853,10 @@ def instance_get_all_by_filters(context, filters, sort_key, sort_dir,
 
     sort_fn = {'desc': desc, 'asc': asc}
 
-    if CONF.database.slave_connection == '':
-        use_slave = False
+    if CONF.database.subordinate_connection == '':
+        use_subordinate = False
 
-    session = get_session(use_slave=use_slave)
+    session = get_session(use_subordinate=use_subordinate)
 
     if columns_to_join is None:
         columns_to_join = ['info_cache', 'security_groups']
@@ -2064,14 +2064,14 @@ def instance_get_active_by_window_joined(context, begin, end=None,
 
 
 def _instance_get_all_query(context, project_only=False,
-                            joins=None, use_slave=False):
+                            joins=None, use_subordinate=False):
     if joins is None:
         joins = ['info_cache', 'security_groups']
 
     query = model_query(context,
                         models.Instance,
                         project_only=project_only,
-                        use_slave=use_slave)
+                        use_subordinate=use_subordinate)
     for join in joins:
         query = query.options(joinedload(join))
     return query
@@ -2080,12 +2080,12 @@ def _instance_get_all_query(context, project_only=False,
 @require_admin_context
 def instance_get_all_by_host(context, host,
                              columns_to_join=None,
-                             use_slave=False):
+                             use_subordinate=False):
     return _instances_fill_metadata(context,
       _instance_get_all_query(context,
-                              use_slave=use_slave).filter_by(host=host).all(),
+                              use_subordinate=use_subordinate).filter_by(host=host).all(),
                               manual_joins=columns_to_join,
-                              use_slave=use_slave)
+                              use_subordinate=use_subordinate)
 
 
 def _instance_get_all_uuids_by_host(context, host, session=None):
@@ -3468,12 +3468,12 @@ def get_snapshot_uuid_by_ec2_id(context, ec2_id):
 
 
 def _block_device_mapping_get_query(context, session=None,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     if columns_to_join is None:
         columns_to_join = []
 
     query = model_query(context, models.BlockDeviceMapping,
-                        session=session, use_slave=use_slave)
+                        session=session, use_subordinate=use_subordinate)
 
     for column in columns_to_join:
         query = query.options(joinedload(column))
@@ -3555,8 +3555,8 @@ def block_device_mapping_update_or_create(context, values, legacy=True):
 
 @require_context
 def block_device_mapping_get_all_by_instance(context, instance_uuid,
-                                             use_slave=False):
-    return _block_device_mapping_get_query(context, use_slave=use_slave).\
+                                             use_subordinate=False):
+    return _block_device_mapping_get_query(context, use_subordinate=use_subordinate).\
                  filter_by(instance_uuid=instance_uuid).\
                  all()
 
@@ -4061,12 +4061,12 @@ def migration_get_by_instance_and_status(context, instance_uuid, status):
 
 @require_admin_context
 def migration_get_unconfirmed_by_dest_compute(context, confirm_window,
-                                              dest_compute, use_slave=False):
+                                              dest_compute, use_subordinate=False):
     confirm_window = (timeutils.utcnow() -
                       datetime.timedelta(seconds=confirm_window))
 
     return model_query(context, models.Migration, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
              filter(models.Migration.updated_at <= confirm_window).\
              filter_by(status="finished").\
              filter_by(dest_compute=dest_compute).\
@@ -4586,11 +4586,11 @@ def cell_get_all(context):
 # User-provided metadata
 
 def _instance_metadata_get_multi(context, instance_uuids,
-                                 session=None, use_slave=False):
+                                 session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4652,11 +4652,11 @@ def instance_metadata_update(context, instance_uuid, metadata, delete):
 
 
 def _instance_system_metadata_get_multi(context, instance_uuids,
-                                        session=None, use_slave=False):
+                                        session=None, use_subordinate=False):
     if not instance_uuids:
         return []
     return model_query(context, models.InstanceSystemMetadata,
-                       session=session, use_slave=use_slave).\
+                       session=session, use_subordinate=use_subordinate).\
                     filter(
             models.InstanceSystemMetadata.instance_uuid.in_(instance_uuids))
 
@@ -4759,9 +4759,9 @@ def agent_build_update(context, agent_build_id, values):
 ####################
 
 @require_context
-def bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+def bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
     return model_query(context, models.BandwidthUsage, read_deleted="yes",
-                       use_slave=use_slave).\
+                       use_subordinate=use_subordinate).\
                            filter_by(start_period=start_period).\
                            filter_by(uuid=uuid).\
                            filter_by(mac=mac).\

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -6144,3 +6144,16 @@ def geo_tag_get_by_id_or_node_name(context, geo_tag_id):
                 filter((models.ComputeNodeGeoTag.id == geo_tag_id) |
                        (models.ComputeNodeGeoTag.server_name == geo_tag_id)).\
                 first()
+
+
+@require_admin_context
+def geo_tag_get_all_by_filters(context, filters):
+    query = model_query(context, models.ComputeNodeGeoTag)
+    if "valid_invalid" in filters:
+        query = query.filter(models.ComputeNodeGeoTag.valid_invalid ==
+                                filters['valid_invalid'])
+    if 'host' in filters:
+        query = query.filter(models.ComputeNodeGeoTag.server_name ==
+                                filters['host'])
+
+    return query.all()

--- a/nova/db/sqlalchemy/migrate_repo/versions/234_add_compute_node_geotag_table.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/234_add_compute_node_geotag_table.py
@@ -1,0 +1,80 @@
+
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Index
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import String
+from sqlalchemy import Table
+from sqlalchemy import Text
+from sqlalchemy import UniqueConstraint
+
+from nova.openstack.common import timeutils
+
+
+def upgrade(engine):
+    meta = MetaData()
+    meta.bind = engine
+    geo_tag_uc_name = 'uniq_node_name_geotag'
+    geo_tags = Table('compute_nodes_geotag', meta,
+        Column('created_at', DateTime(timezone=False)),
+        Column('updated_at', DateTime(timezone=False)),
+        Column('deleted_at', DateTime(timezone=False)),
+        Column('deleted', Integer, default=0),
+        Column('id', Integer, primary_key=True),
+        
+        
+        Column('server_name', String(255), nullable=False),
+        
+        Column('ip_address', String(39)),
+        Column('mac_address', String(17)),
+        Column('parent_mac', String(17)),
+        Column('time_data_rec', String(28)),
+        Column('rfid', String(24)),
+        Column('rfid_signature', String(10)),
+        Column('plt_longitude', String(11)),
+        Column('plt_latitude', String(11)),
+        Column('loc_or_error_msg', String(17)),
+        Column('valid_invalid', String(7)),
+        Column('rfid_scan_time', String(19)),
+        Column('rfid_rec_time', String(19)),
+        Column('geo_loc_valid_time', String(19)),
+        Column('geo_loc_invalid_time', String(19)),
+        Column('secure_geo_loc', String(10)),
+        Column('auto_geo_loc', String(10)),
+        Column('cable_disc_prd', String(10)),
+        Column('geo_loc_server', String(5)),
+        Column('node_manager', String(5)),
+        Column('platform_guid', String(32)),
+        Column('geo_loc_svr_guid', String(32)),
+        Column('rfid_reader_guid', String(32)),
+
+        Column('alerts', Integer),
+        
+        Index('compute_name_gt_tag_valid_idx',
+              'server_name', 'valid_invalid'),
+        UniqueConstraint('server_name', name=geo_tag_uc_name),
+        mysql_engine='InnoDB',
+        mysql_charset='utf8')
+
+    geo_tags.create()
+
+
+def downgrade(engine):
+    pass

--- a/nova/db/sqlalchemy/migrate_repo/versions/234_add_compute_node_geotag_table.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/234_add_compute_node_geotag_table.py
@@ -16,16 +16,12 @@
 
 from sqlalchemy import Column
 from sqlalchemy import DateTime
-from sqlalchemy import ForeignKey
 from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import String
 from sqlalchemy import Table
-from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
-
-from nova.openstack.common import timeutils
 
 
 def upgrade(engine):
@@ -38,10 +34,7 @@ def upgrade(engine):
         Column('deleted_at', DateTime(timezone=False)),
         Column('deleted', Integer, default=0),
         Column('id', Integer, primary_key=True),
-        
-        
         Column('server_name', String(255), nullable=False),
-        
         Column('ip_address', String(39)),
         Column('mac_address', String(17)),
         Column('parent_mac', String(17)),
@@ -64,9 +57,7 @@ def upgrade(engine):
         Column('platform_guid', String(32)),
         Column('geo_loc_svr_guid', String(32)),
         Column('rfid_reader_guid', String(32)),
-
         Column('alerts', Integer),
-        
         Index('compute_name_gt_tag_valid_idx',
               'server_name', 'valid_invalid'),
         UniqueConstraint('server_name', name=geo_tag_uc_name),

--- a/nova/db/sqlalchemy/migrate_repo/versions/235_add_power_state_geotag_col.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/235_add_power_state_geotag_col.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2014 Rackspace Hosting
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Index
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import String
+from sqlalchemy import Table
+from sqlalchemy import Text
+
+from nova.openstack.common import timeutils
+
+
+def upgrade(engine):
+    meta = MetaData()
+    meta.bind = engine
+
+    # Add a new power_state column to geo tags 
+    table_name = 'compute_nodes_geotag'
+    table = Table(table_name, meta, autoload=True)
+    stats = Column('power_state', String(50), default=None)
+    table.create_column(stats)
+
+
+def downgrade(engine):
+    meta = MetaData()
+    meta.bind = engine
+
+    table_names = 'compute_nodes_geotag'
+    table = Table(table_name, meta, autoload=True)
+    table.drop_column('power_state')
+    
+    

--- a/nova/db/sqlalchemy/models.py
+++ b/nova/db/sqlalchemy/models.py
@@ -1431,7 +1431,7 @@ class ComputeNodeGeoTag(BASE, NovaBase):
     geo_loc_server = Column(String(5))
     node_manager = Column(String(5))
     alerts = Column(Integer)
-    power_state = Column(String(15), nullable=True)
+    power_state = Column(String(50), nullable=True)
     server_name = Column(String(255), nullable=True)
     #can exists or not...
     #node_data = relationship(ComputeNode, backref="geo_tags",

--- a/nova/db/sqlalchemy/models.py
+++ b/nova/db/sqlalchemy/models.py
@@ -1431,8 +1431,8 @@ class ComputeNodeGeoTag(BASE, NovaBase):
     geo_loc_server = Column(String(5))
     node_manager = Column(String(5))
     alerts = Column(Integer)
-
-    server_name = Column(String(255), nullable=False)
+    power_state = Column(String(15), nullable=True)
+    server_name = Column(String(255), nullable=True)
     #can exists or not...
     #node_data = relationship(ComputeNode, backref="geo_tags",
     #                        foreign_keys=server_name,

--- a/nova/db/sqlalchemy/models.py
+++ b/nova/db/sqlalchemy/models.py
@@ -1395,3 +1395,53 @@ class PciDevice(BASE, NovaBase):
                             primaryjoin='and_('
                             'PciDevice.instance_uuid == Instance.uuid,'
                             'PciDevice.deleted == 0)')
+
+class ComputeNodeGeoTag(BASE, NovaBase):
+    """Represents geotag information"""
+    __tablename__ = 'compute_nodes_geotag'
+    __table_args__ = (
+           Index('compute_name_gt_tag_valid_idx', 'server_name', 'valid_invalid'),
+        
+    )
+    
+    id = Column(Integer, primary_key=True)
+    
+   
+    ip_address = Column(types.IPAddress())
+    mac_address = Column(String(17))
+    parent_mac = Column(String(17))
+    #should be covered by upated_at when using
+    #the api to change this values
+    time_data_rec = Column(String(28))
+    
+    rfid = Column(String(24))
+    rfid_signature = Column(String(10))
+    platform_guid = Column(String(32))
+    geo_loc_svr_guid = Column(String(32))
+    rfid_reader_guid = Column(String(32))
+    #create a field for this type of data , some dbs
+    #have specific columns (posgres for instance)
+    plt_latitude = Column(String(11))
+    plt_longitude = Column(String(11))
+    loc_or_error_msg = Column(String(17))
+    valid_invalid = Column(String(7))
+    rfid_scan_time = Column(String(19))
+    rfid_rec_time = Column(String(19))
+    geo_loc_valid_time = Column(String(19))
+    geo_loc_invalid_time = Column(String(19))
+    secure_geo_loc = Column(String(10))
+    auto_geo_loc = Column(String(10))
+    cable_disc_prd = Column(String(10))
+    geo_loc_server = Column(String(5))
+    node_manager = Column(String(5))
+    alerts = Column(Integer)
+    
+
+    server_name = Column(String(255), nullable=False)
+    #can exists or not...
+    #node_data = relationship(ComputeNode, backref="geo_tags",
+    #                        foreign_keys=server_name,
+    #                        primaryjoin='and_('
+    #                            'ComputeNode.hypervisor_hostname == server_name ')
+                                   
+

--- a/nova/db/sqlalchemy/models.py
+++ b/nova/db/sqlalchemy/models.py
@@ -1396,24 +1396,20 @@ class PciDevice(BASE, NovaBase):
                             'PciDevice.instance_uuid == Instance.uuid,'
                             'PciDevice.deleted == 0)')
 
+
 class ComputeNodeGeoTag(BASE, NovaBase):
-    """Represents geotag information"""
+    """Represents geotag information."""
     __tablename__ = 'compute_nodes_geotag'
     __table_args__ = (
-           Index('compute_name_gt_tag_valid_idx', 'server_name', 'valid_invalid'),
-        
+        Index('compute_name_gt_tag_valid_idx', 'server_name', 'valid_invalid'),
     )
-    
     id = Column(Integer, primary_key=True)
-    
-   
     ip_address = Column(types.IPAddress())
     mac_address = Column(String(17))
     parent_mac = Column(String(17))
     #should be covered by upated_at when using
     #the api to change this values
     time_data_rec = Column(String(28))
-    
     rfid = Column(String(24))
     rfid_signature = Column(String(10))
     platform_guid = Column(String(32))
@@ -1435,13 +1431,10 @@ class ComputeNodeGeoTag(BASE, NovaBase):
     geo_loc_server = Column(String(5))
     node_manager = Column(String(5))
     alerts = Column(Integer)
-    
 
     server_name = Column(String(255), nullable=False)
     #can exists or not...
     #node_data = relationship(ComputeNode, backref="geo_tags",
     #                        foreign_keys=server_name,
     #                        primaryjoin='and_('
-    #                            'ComputeNode.hypervisor_hostname == server_name ')
-                                   
-
+    #                       'ComputeNode.hypervisor_hostname == server_name ')

--- a/nova/db/sqlalchemy/utils.py
+++ b/nova/db/sqlalchemy/utils.py
@@ -114,7 +114,7 @@ def _get_unique_constraints_in_sqlite(migrate_engine, table_name):
         """
             SELECT sql
             FROM
-                sqlite_master
+                sqlite_main
             WHERE
                 type = 'table' AND
                 name = :table_name;

--- a/nova/exception.py
+++ b/nova/exception.py
@@ -1543,5 +1543,6 @@ class NoBlockMigrationForConfigDriveInLibVirt(NovaException):
     msg_fmt = _("Block migration of instances with config drives is not "
                 "supported in libvirt.")
 
+
 class GeoTagExists(NovaException):
     msg_fmt = _("GeoTag for  %(name)s already exists.")

--- a/nova/exception.py
+++ b/nova/exception.py
@@ -1542,3 +1542,6 @@ class InvalidWatchdogAction(Invalid):
 class NoBlockMigrationForConfigDriveInLibVirt(NovaException):
     msg_fmt = _("Block migration of instances with config drives is not "
                 "supported in libvirt.")
+
+class GeoTagExists(NovaException):
+    msg_fmt = _("GeoTag for  %(name)s already exists.")

--- a/nova/network/ldapdns.py
+++ b/nova/network/ldapdns.py
@@ -42,9 +42,9 @@ ldap_dns_opts = [
                default='password',
                help='Password for LDAP DNS',
                secret=True),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-               default='hostmaster@example.org',
-               help='Hostmaster for LDAP DNS driver Statement of Authority'),
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+               default='hostmain@example.org',
+               help='Hostmain for LDAP DNS driver Statement of Authority'),
     cfg.MultiStrOpt('ldap_dns_servers',
                     default=['dns.example.org'],
                     help='DNS Servers for LDAP DNS driver'),
@@ -156,7 +156,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %s %s %s %s' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/nova/network/linux_net.py
+++ b/nova/network/linux_net.py
@@ -1564,7 +1564,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
                          run_as_root=True)
 
             if (err and err != "device %s is already a member of a bridge;"
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/nova/network/manager.py
+++ b/nova/network/manager.py
@@ -581,14 +581,14 @@ class NetworkManager(manager.Manager):
         where network = dict containing pertinent data from a network db object
         and info = dict containing pertinent networking data
         """
-        use_slave = kwargs.get('use_slave') or False
+        use_subordinate = kwargs.get('use_subordinate') or False
 
         if not uuidutils.is_uuid_like(instance_id):
             instance_id = instance_uuid
         instance_uuid = instance_id
 
         vifs = vif_obj.VirtualInterfaceList.get_by_instance_uuid(context,
-                instance_uuid, use_slave=use_slave)
+                instance_uuid, use_subordinate=use_subordinate)
         networks = {}
 
         for vif in vifs:

--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -453,13 +453,13 @@ class API(base.Base):
 
     @refresh_cache
     def get_instance_nw_info(self, context, instance, networks=None,
-                             port_ids=None, use_slave=False):
+                             port_ids=None, use_subordinate=False):
         """Return network information for specified instance
            and update cache.
         """
-        # NOTE(geekinutah): It would be nice if use_slave had us call
-        #                   special APIs that pummeled slaves instead of
-        #                   the master. For now we just ignore this arg.
+        # NOTE(geekinutah): It would be nice if use_subordinate had us call
+        #                   special APIs that pummeled subordinates instead of
+        #                   the main. For now we just ignore this arg.
         result = self._get_instance_nw_info(context, instance, networks,
                                             port_ids)
         return result

--- a/nova/objects/block_device.py
+++ b/nova/objects/block_device.py
@@ -175,7 +175,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject):
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     VERSION = '1.2'
 
     fields = {
@@ -188,9 +188,9 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     }
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = db.block_device_mapping_get_all_by_instance(
-                context, instance_uuid, use_slave=use_slave)
+                context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), BlockDeviceMapping, db_bdms or [])
 

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -17,7 +17,7 @@ from nova import exception
 from nova.objects import base
 from nova.objects import fields
 from nova.openstack.common import jsonutils
-from nova.objects import geo_tags
+
 
 class ComputeNode(base.NovaPersistentObject, base.NovaObject):
     # Version 1.0: Initial version
@@ -55,8 +55,6 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
         if target_version < (1, 3) and 'stats' in primitive:
             # pre 1.3 version does not have a stats field
             del primitive['stats']
-        #TODO: update target version
-        
 
     @staticmethod
     def _from_db_object(context, compute, db_compute):
@@ -67,10 +65,9 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
         stats = db_compute['stats']
         if stats:
             compute['stats'] = jsonutils.loads(stats)
-        
-        #compute['geo_tags'] = geo_tags.GeoTag.get_by_node_name(context, db_compute['hypervisor_hostname'])
-        
-                                                
+
+        #compute['geo_tags'] = geo_tags.GeoTag.get_by_node_nam
+        #(context, db_compute['hypervisor_hostname'])
         compute._context = context
         compute.obj_reset_changes()
         return compute
@@ -128,6 +125,7 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
 
     def obj_make_compatible(self, primitive, target_version):
         pass
+
 
 class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -17,7 +17,7 @@ from nova import exception
 from nova.objects import base
 from nova.objects import fields
 from nova.openstack.common import jsonutils
-
+from nova.objects import geo_tags
 
 class ComputeNode(base.NovaPersistentObject, base.NovaObject):
     # Version 1.0: Initial version
@@ -45,7 +45,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
         'cpu_info': fields.StringField(nullable=True),
         'disk_available_least': fields.IntegerField(nullable=True),
         'metrics': fields.StringField(nullable=True),
-        'stats': fields.DictOfNullableStringsField(nullable=True),
+        'stats': fields.DictOfNullableStringsField(nullable=True)
+#        'geo_tags': fields.DictOfStringsField(),
         }
 
     def obj_make_compatible(self, primitive, target_version):
@@ -54,10 +55,11 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
         if target_version < (1, 3) and 'stats' in primitive:
             # pre 1.3 version does not have a stats field
             del primitive['stats']
+        #TODO: update target version
+        
 
     @staticmethod
     def _from_db_object(context, compute, db_compute):
-
         fields = set(compute.fields) - set(['stats'])
         for key in fields:
             compute[key] = db_compute[key]
@@ -65,7 +67,10 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
         stats = db_compute['stats']
         if stats:
             compute['stats'] = jsonutils.loads(stats)
-
+        
+        #compute['geo_tags'] = geo_tags.GeoTag.get_by_node_name(context, db_compute['hypervisor_hostname'])
+        
+                                                
         compute._context = context
         compute.obj_reset_changes()
         return compute
@@ -121,6 +126,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
                                                              self.service_id)
         return self._cached_service
 
+    def obj_make_compatible(self, primitive, target_version):
+        pass
 
 class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -48,8 +48,6 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
 
     def __init__(self, *args, **kwargs):
         super(GeoTag, self).__init__(*args, **kwargs)
-        self.obj_reset_changes()
-        self.extra_info = {}
 
     @staticmethod
     def _from_db_object(context, geo_tag, db_dev):
@@ -85,7 +83,6 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
                                               reason='already created')
         updates = self.obj_get_changes()
         updates.pop('id', None)
-        print "UPDAtEs: ", updates
         db_gtag = db.geo_tag_create(context, updates)
         self._from_db_object(context, self, db_gtag)
 
@@ -97,7 +94,7 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
         """
         updates.pop('id', None)
         db_geo_tag = db.geo_tag_update(context, self.id, updates)
-        return self._from_db_object(context, self, db_geo_tag)
+        self._from_db_object(context, self, db_geo_tag)
 
     @base.remotable
     def destroy(self, context):
@@ -118,7 +115,7 @@ class GeoTagList(base.ObjectListBase, base.NovaObject):
     def get_all(cls, context, filters=None):
         db_dev = db.geo_tag_get_all(context, filters)
         return base.obj_make_list(context, GeoTagList(), GeoTag, db_dev)
-    
+
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters):
         db_dev = db.geo_tags_get_all_by_filters(context, filters)

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -43,7 +43,8 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
         'plt_latitude': fields.StringField(nullable=True),
         'plt_longitude': fields.StringField(nullable=True),
         'rfid': fields.StringField(nullable=True),
-        'rfid_signature': fields.StringField(nullable=True)
+        'rfid_signature': fields.StringField(nullable=True),
+        'loc_or_error_msg': fields.StringField(nullable=True)
     }
 
     def __init__(self, *args, **kwargs):

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -44,7 +44,8 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
         'plt_longitude': fields.StringField(nullable=True),
         'rfid': fields.StringField(nullable=True),
         'rfid_signature': fields.StringField(nullable=True),
-        'loc_or_error_msg': fields.StringField(nullable=True)
+        'loc_or_error_msg': fields.StringField(nullable=True),
+        'power_state': fields.StringField(nullable=True)
     }
 
     def __init__(self, *args, **kwargs):

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -85,7 +85,7 @@ class GeoTag(base.NovaPersistentObject, base.NovaObject):
                                               reason='already created')
         updates = self.obj_get_changes()
         updates.pop('id', None)
-
+        print "UPDAtEs: ", updates
         db_gtag = db.geo_tag_create(context, updates)
         self._from_db_object(context, self, db_gtag)
 
@@ -122,5 +122,5 @@ class GeoTagList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters):
         db_dev = db.geo_tags_get_all_by_filters(context, filters)
-        return base.obj_make_list(context, GeoTagsList(), GeoTag,
+        return base.obj_make_list(context, GeoTagList(), GeoTag,
                                   db_dev)

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -118,3 +118,9 @@ class GeoTagList(base.ObjectListBase, base.NovaObject):
     def get_all(cls, context, filters=None):
         db_dev = db.geo_tag_get_all(context, filters)
         return base.obj_make_list(context, GeoTagList(), GeoTag, db_dev)
+    
+    @base.remotable_classmethod
+    def get_by_filters(cls, context, filters):
+        db_dev = db.geo_tags_get_all_by_filters(context, filters)
+        return base.obj_make_list(context, GeoTagsList(), GeoTag,
+                                  db_dev)

--- a/nova/objects/geo_tags.py
+++ b/nova/objects/geo_tags.py
@@ -1,0 +1,120 @@
+# Copyright 2013 Intel Corporation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from nova import db
+from nova import exception
+from nova.objects import base
+from nova.objects import fields
+from nova.openstack.common import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+class GeoTag(base.NovaPersistentObject, base.NovaObject):
+
+    """Object to represent GeoTag Info
+    """
+
+    # Version 1.0: Initial version
+    # Version 1.1: String attributes updated to support unicode
+    VERSION = '1.0'
+
+    fields = {
+        'id': fields.IntegerField(),
+        'alerts': fields.IntegerField(nullable=True),
+        'server_name': fields.StringField(nullable=True),
+        'ip_address': fields.StringField(nullable=True),
+        'mac_address': fields.StringField(nullable=True),
+        'parent_mac': fields.StringField(nullable=True),
+        'valid_invalid': fields.StringField(default='Valid'),
+        'plt_latitude': fields.StringField(nullable=True),
+        'plt_longitude': fields.StringField(nullable=True),
+        'rfid': fields.StringField(nullable=True),
+        'rfid_signature': fields.StringField(nullable=True)
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(GeoTag, self).__init__(*args, **kwargs)
+        self.obj_reset_changes()
+        self.extra_info = {}
+
+    @staticmethod
+    def _from_db_object(context, geo_tag, db_dev):
+        if not db_dev:
+            return None
+        for key in geo_tag.fields:
+            geo_tag[key] = db_dev[key]
+
+        geo_tag._context = context
+        geo_tag.obj_reset_changes()
+        return geo_tag
+
+    @base.remotable_classmethod
+    def get_by_node_name(cls, context, name):
+        db_dev = db.geo_tag_get_by_node_name(context, name)
+        return cls._from_db_object(context, cls(), db_dev)
+
+    @base.remotable_classmethod
+    def get_by_id(cls, context, gt_id):
+        db_dev = db.geo_tag_get_by_id(context, gt_id)
+        return cls._from_db_object(context, cls(), db_dev)
+
+    @base.remotable_classmethod
+    def get_by_id_or_node_name(cls, context, gt_id):
+        db_dev = db.geo_tag_get_by_id_or_node_name(context, gt_id)
+        return cls._from_db_object(context, cls(), db_dev)
+
+    @base.remotable
+    def create(self, context):
+        """Create a Geo Tag."""
+        if self.obj_attr_is_set('id'):
+            raise exception.ObjectActionError(action='create',
+                                              reason='already created')
+        updates = self.obj_get_changes()
+        updates.pop('id', None)
+
+        db_gtag = db.geo_tag_create(context, updates)
+        self._from_db_object(context, self, db_gtag)
+
+    @base.remotable
+    def save(self, context):
+        updates = self.obj_get_changes()
+        """
+        set notif?
+        """
+        updates.pop('id', None)
+        db_geo_tag = db.geo_tag_update(context, self.id, updates)
+        return self._from_db_object(context, self, db_geo_tag)
+
+    @base.remotable
+    def destroy(self, context):
+        db.geo_tag_destroy(context, self.id)
+
+
+class GeoTagList(base.ObjectListBase, base.NovaObject):
+    # Version 1.0: Initial version
+
+    VERSION = '1.0'
+
+    fields = {
+        'objects': fields.ListOfObjectsField('GeoTag'),
+        }
+    child_versions = {}
+
+    @base.remotable_classmethod
+    def get_all(cls, context, filters=None):
+        db_dev = db.geo_tag_get_all(context, filters)
+        return base.obj_make_list(context, GeoTagList(), GeoTag, db_dev)

--- a/nova/objects/migration.py
+++ b/nova/objects/migration.py
@@ -83,7 +83,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject):
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     VERSION = '1.1'
 
     fields = {
@@ -97,9 +97,9 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = db.migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, MigrationList(), Migration,
                                   db_migrations)
 

--- a/nova/objects/service.py
+++ b/nova/objects/service.py
@@ -45,7 +45,6 @@ class Service(base.NovaPersistentObject, base.NovaObject):
         'availability_zone': fields.StringField(nullable=True),
         'compute_node': fields.ObjectField('ComputeNode'),
         'geo_tag': fields.ObjectField('GeoTag', nullable=True),
-        
         }
 
     @staticmethod
@@ -60,13 +59,14 @@ class Service(base.NovaPersistentObject, base.NovaObject):
         service.compute_node = compute_node.ComputeNode._from_db_object(
             context, compute_node.ComputeNode(), db_compute)
 
-    #(licostan) must be removed after poc, maybe place this into computenode hypervisors
-    #when migrated to objects
+    #(licostan) must be removed after poc, maybe place this into computenode
+    #hypervisors when migrated to objects
     @staticmethod
     def _do_geo_tag(context, service, db_service):
         #if it's a compute-node only
         if db_service['topic'] == six.text_type('compute'):
-            geo_tag = geo_tags.GeoTag.get_by_node_name(context, db_service['host'])
+            geo_tag = geo_tags.GeoTag.get_by_node_name(context,
+                                                       db_service['host'])
             if geo_tag:
                 service.geo_tag = geo_tag
         else:
@@ -75,7 +75,6 @@ class Service(base.NovaPersistentObject, base.NovaObject):
     @staticmethod
     def _from_db_object(context, service, db_service):
         allow_missing = ('availability_zone',)
-        
         for key in service.fields:
             if key in allow_missing and key not in db_service:
                 continue
@@ -103,10 +102,12 @@ class Service(base.NovaPersistentObject, base.NovaObject):
                 action='obj_load_attr',
                 reason='attribute %s not lazy-loadable' % attrname)
         if attrname == 'geo_tag':
-            self.geo_tag = geo_tags.GeoTag.get_by_node_name(self._context, self.host)
+            self.geo_tag = geo_tags.GeoTag.get_by_node_name(self._context,
+                                                            self.host)
         else:
             self.compute_node = compute_node.ComputeNode.get_by_service_id(
                 self._context, self.id)
+
     @base.remotable_classmethod
     def get_by_id(cls, context, service_id):
         db_service = db.service_get(context, service_id)

--- a/nova/objects/virtual_interface.py
+++ b/nova/objects/virtual_interface.py
@@ -93,7 +93,7 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
         return base.obj_make_list(context, cls(), VirtualInterface, db_vifs)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = db.virtual_interface_get_by_instance(context, instance_uuid,
-                use_slave=use_slave)
+                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(), VirtualInterface, db_vifs)

--- a/nova/openstack/common/db/sqlalchemy/migration.py
+++ b/nova/openstack/common/db/sqlalchemy/migration.py
@@ -64,7 +64,7 @@ def _get_unique_constraints(self, table):
 
     data = table.metadata.bind.execute(
         """SELECT sql
-           FROM sqlite_master
+           FROM sqlite_main
            WHERE
                type='table' AND
                name=:table_name""",

--- a/nova/openstack/common/gettextutils.py
+++ b/nova/openstack/common/gettextutils.py
@@ -326,9 +326,9 @@ def get_available_languages(domain):
     # order matters) since our in-line message strings are en_US
     language_list = ['en_US']
     # NOTE(luisg): Babel <1.0 used a function called list(), which was
-    # renamed to locale_identifiers() in >=1.0, the requirements master list
+    # renamed to locale_identifiers() in >=1.0, the requirements main list
     # requires >=0.9.6, uncapped, so defensively work with both. We can remove
-    # this check when the master list updates to >=1.0, and update all projects
+    # this check when the main list updates to >=1.0, and update all projects
     list_identifiers = (getattr(localedata, 'list', None) or
                         getattr(localedata, 'locale_identifiers'))
     locale_identifiers = list_identifiers()

--- a/nova/scheduler/filters/affinity_filter.py
+++ b/nova/scheduler/filters/affinity_filter.py
@@ -64,7 +64,7 @@ class SameHostFilter(AffinityFilter):
     def host_passes(self, host_state, filter_properties):
         context = filter_properties['context']
         scheduler_hints = filter_properties.get('scheduler_hints') or {}
-
+        LOG.debug('Samehost Filter running')
         affinity_uuids = scheduler_hints.get('same_host', [])
         if isinstance(affinity_uuids, six.string_types):
             affinity_uuids = [affinity_uuids]

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -15,7 +15,7 @@
 
 from oslo.config import cfg
 
-from nova import db
+from nova.objects import geo_tags as geo_tags_obj
 from nova.openstack.common import log as logging
 from nova.scheduler import filters
 
@@ -37,9 +37,10 @@ class GeoTagsFilter(filters.BaseHostFilter):
         geo_tags = scheduler_hints.get('geo_tags', None)
 
         #filters = {'host': host_state.host, 'valid_invalid': 'Valid'}
-        #(licostan): Should we use objects? don't know... 
+        #(licostan): Should we use objects? don't know...
         #anyways this call should not happen in production
-        geo_tag = db.geo_tag_get_by_node_name(context, host_state.host)
+        geo_tag = geo_tags_obj.GeoTag.get_by_node_name(context,
+                                                       host_state.host)
         if not geo_tag:
             LOG.info('NO GEO TAG FOUND FOR %s' % host_state.host)
             return True
@@ -50,5 +51,4 @@ class GeoTagsFilter(filters.BaseHostFilter):
             return True
 
         LOG.info('GEO TAG INVALID FOR  %s' % host_state.host)
-        #always true for now.
         return False

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -35,8 +35,6 @@ class GeoTagsFilter(filters.BaseHostFilter):
         #something like that..... ( host_state.geo_tag for instance),
         #instead of querying the db
         geo_tags = scheduler_hints.get('geo_tags', None)
-        if not geo_tags:
-            return True
 
         #filters = {'host': host_state.host, 'valid_invalid': 'Valid'}
         geo_tag = db.geo_tag_get_by_node_name(context, host_state.host)
@@ -44,10 +42,11 @@ class GeoTagsFilter(filters.BaseHostFilter):
             LOG.info('NO GEO TAG FOUND FOR %s' % host_state.host)
             return True
 
-        if geo_tag.valid_invalid == 'Valid':
+        if geo_tag.valid_invalid.lower() == 'valid':
+            #check geo_tags here if needed
             LOG.info('GEO TAG FOUND FOR %s' % host_state.host)
             return True
 
         LOG.info('GEO TAG INVALID FOR  %s' % host_state.host)
         #always true for now.
-        return True
+        return False

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2012 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo.config import cfg
+
+from nova import db
+from nova.openstack.common import log as logging
+from nova.scheduler import filters
+
+CONF = cfg.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class GeoTagsFilter(filters.BaseHostFilter):
+    """Filter on geo tags filters if available."""
+
+    def host_passes(self, host_state, filter_properties):
+        context = filter_properties['context']
+        scheduler_hints = filter_properties.get('scheduler_hints') or {}
+        #(licostan): in the future, HostManager shall include geo_tag filters
+        #if it's going to be updated by each compute-node itself tru ipmi or
+        #something like that..... ( host_state.geo_tag for instance),
+        #instead of querying the db
+        geo_tags = scheduler_hints.get('geo_tags', None)
+        if not geo_tags:
+            return True
+
+        #filters = {'host': host_state.host, 'valid_invalid': 'Valid'}
+        geo_tag = db.geo_tag_get_by_node_name(context, host_state.host)
+        if not geo_tag:
+            LOG.info('NO GEO TAG FOUND FOR %s' % host_state.host)
+            return True
+
+        if geo_tag.valid_invalid == 'Valid':
+            LOG.info('GEO TAG FOUND FOR %s' % host_state.host)
+            return True
+
+        LOG.info('GEO TAG INVALID FOR  %s' % host_state.host)
+        #always true for now.
+        return True

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -37,12 +37,14 @@ class GeoTagsFilter(filters.BaseHostFilter):
         geo_tags = scheduler_hints.get('geo_tags', None)
 
         #filters = {'host': host_state.host, 'valid_invalid': 'Valid'}
+        #(licostan): Should we use objects? don't know... 
+        #anyways this call should not happen in production
         geo_tag = db.geo_tag_get_by_node_name(context, host_state.host)
         if not geo_tag:
             LOG.info('NO GEO TAG FOUND FOR %s' % host_state.host)
             return True
 
-        if geo_tag.valid_invalid.lower() == 'valid':
+        if geo_tag['valid_invalid'].lower() == 'valid':
             #check geo_tags here if needed
             LOG.info('GEO TAG FOUND FOR %s' % host_state.host)
             return True

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -29,8 +29,13 @@ class GeoTagsFilter(filters.BaseHostFilter):
     """Filter on geo tags filters if available."""
 
     def _is_valid_rack_loc(self, host_rack, wanted_rack):
-        rack_aff = zip(wanted_rack.split('-'), host_rack.split('-'))
+        wanted = wanted_rack.split('-')
+        host = host_rack.split('-')
+        if not wanted[-1]:
+            wanted.pop()
+        rack_aff = zip(wanted, host)
         for x, v in rack_aff:
+            #may be empty due to to split
             if x != v:
                 return False
         return True

--- a/nova/scheduler/filters/geo_tags_filter.py
+++ b/nova/scheduler/filters/geo_tags_filter.py
@@ -16,6 +16,7 @@
 from oslo.config import cfg
 
 from nova.objects import geo_tags as geo_tags_obj
+from nova.openstack.common import jsonutils
 from nova.openstack.common import log as logging
 from nova.scheduler import filters
 
@@ -27,6 +28,13 @@ LOG = logging.getLogger(__name__)
 class GeoTagsFilter(filters.BaseHostFilter):
     """Filter on geo tags filters if available."""
 
+    def _is_valid_rack_loc(self, host_rack, wanted_rack):
+        rack_aff = zip(wanted_rack.split('-'), host_rack.split('-'))
+        for x, v in rack_aff:
+            if x != v:
+                return False
+        return True
+
     def host_passes(self, host_state, filter_properties):
         context = filter_properties['context']
         scheduler_hints = filter_properties.get('scheduler_hints') or {}
@@ -34,9 +42,12 @@ class GeoTagsFilter(filters.BaseHostFilter):
         #if it's going to be updated by each compute-node itself tru ipmi or
         #something like that..... ( host_state.geo_tag for instance),
         #instead of querying the db
-        geo_tags = scheduler_hints.get('geo_tags', None)
-
-        #filters = {'host': host_state.host, 'valid_invalid': 'Valid'}
+        try:
+            geo_tags_hint = jsonutils.loads(scheduler_hints.get('geo_tags',
+                                                                '{}'))
+        except Exception as e:
+            LOG.error('Cannot parse json gtags')
+            return False
         #(licostan): Should we use objects? don't know...
         #anyways this call should not happen in production
         geo_tag = geo_tags_obj.GeoTag.get_by_node_name(context,
@@ -45,10 +56,19 @@ class GeoTagsFilter(filters.BaseHostFilter):
             LOG.info('NO GEO TAG FOUND FOR %s' % host_state.host)
             return True
 
-        if geo_tag['valid_invalid'].lower() == 'valid':
+        if geo_tag['valid_invalid'].lower() != 'valid':
             #check geo_tags here if needed
-            LOG.info('GEO TAG FOUND FOR %s' % host_state.host)
-            return True
+            LOG.info('GEO TAG Invalid  FOR %s' % host_state.host)
+            return False
 
-        LOG.info('GEO TAG INVALID FOR  %s' % host_state.host)
-        return False
+        wanted_rack = geo_tags_hint.get('rack_location', None)
+        host_loc = geo_tag.get('loc_or_error_msg')
+
+        if wanted_rack and not self._is_valid_rack_loc(host_loc, wanted_rack):
+            LOG.info('Invalid rack location wanted: %(want)s '
+                     ' host_loc: %(host_loc)s' % {'want': wanted_rack,
+                                                 'host_loc': host_loc})
+            return False
+
+        LOG.info('GEO TAG VALID FOR  %s' % host_state.host)
+        return True

--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -49,7 +49,9 @@ host_manager_opts = [
                   'RamFilter',
                   'ComputeFilter',
                   'ComputeCapabilitiesFilter',
-                  'ImagePropertiesFilter'
+                  'ImagePropertiesFilter',
+                  #(licostan): to avoid changing conf.... remove after POC
+                  'GeoTagsFilter',
                   ],
                 help='Which filter class names to use for filtering hosts '
                       'when not specified in the request.'),

--- a/nova/tests/api/ec2/test_cloud.py
+++ b/nova/tests/api/ec2/test_cloud.py
@@ -2380,7 +2380,7 @@ class CloudTestCase(test.TestCase):
         self.stubs.Set(fake._FakeImageService, 'show', fake_show)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],
@@ -2455,7 +2455,7 @@ class CloudTestCase(test.TestCase):
         ec2_instance_id = self._run_instance(**kwargs)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': volumes[0],
                          'snapshot_id': snapshots[0],

--- a/nova/tests/api/openstack/compute/contrib/test_disk_config.py
+++ b/nova/tests/api/openstack/compute/contrib/test_disk_config.py
@@ -65,7 +65,7 @@ class DiskConfigTestCase(test.TestCase):
         self.stubs.Set(db, 'instance_get', fake_instance_get)
 
         def fake_instance_get_by_uuid(context, uuid,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             for instance in FAKE_INSTANCES:
                 if uuid == instance['uuid']:
                     return instance

--- a/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
+++ b/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
@@ -77,7 +77,7 @@ class GeotagsTest(test.NoDBTestCase):
         first_gt = res_dict['geo_tags'][0]
         self.assertTrue(first_gt.server_name, self.db_list[0]['server_name'])
         second_gt = res_dict['geo_tags'][1]
-        self.assertEquals(second_gt.server_name,
+        self.assertEqual(second_gt.server_name,
                           self.db_list[1]['server_name'])
         db_mock.assert_called_once_with(req.environ['nova.context'], {})
 
@@ -94,7 +94,7 @@ class GeotagsTest(test.NoDBTestCase):
 
         req = FakeRequest()
         res_dict = self.controller.create(req, body)
-        self.assertEquals(res_dict['geo_tag'].server_name, 'server3')
+        self.assertEqual(res_dict['geo_tag'].server_name, 'server3')
         expected = dict(body['geo_tag'])
         #(licostan): BIG NOTE, normalize server-name to compute_name
         #if we go por
@@ -130,7 +130,7 @@ class GeotagsTest(test.NoDBTestCase):
 
         req = FakeRequest()
         res_dict = self.controller.update(req, 'server4', body)
-        self.assertEquals(res_dict['geo_tag'].server_name, 'server4')
+        self.assertEqual(res_dict['geo_tag'].server_name, 'server4')
         expected = dict(body['geo_tag'])
         #(licostan): BIG NOTE, normalize server-name to compute_name
         #if we go por
@@ -141,7 +141,7 @@ class GeotagsTest(test.NoDBTestCase):
     @mock.patch('nova.db.geo_tag_destroy')
     @mock.patch('nova.db.geo_tag_get_by_id_or_node_name')
     def test_geo_tags_delete(self, geo_tag_get_mock, geo_tag_destroy_mock):
-        #(licostan): Why the get? just destroy?... TODO
+        #TODO(licostan): Why the get? just destroy?... TODO
         obj = fake_geotag_db(4, 'server4', 'Inactive', 11, 11)
         geo_tag_get_mock.return_value = obj
         req = FakeRequest()

--- a/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
+++ b/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
@@ -106,7 +106,7 @@ class GeotagsTest(test.NoDBTestCase):
     def test_geo_tags_create_fails_invalid_host(self, host_exists_mock):
         host = 'xxxserver3'
         host_exists_mock.side_effect = exception.ComputeHostNotFound(host=host)
-        body = {'geo_tag': {'compute_name': host,
+        body = {'geo_tag': {'compute_name': 'xxxserver3',
                             'valid_invalid': 'Valid',
                             'plt_longitude': '33',
                             'plt_latitude': '44'}}
@@ -124,8 +124,7 @@ class GeotagsTest(test.NoDBTestCase):
         geo_tag_get_mock.return_value = obj
         geo_tag_update_mock.return_value = obj
 
-        body = {'geo_tag': {'compute_name': 'server4',
-                            'valid_invalid': 'Valid',
+        body = {'geo_tag': {'valid_invalid': 'Valid',
                             'plt_longitude': '33',
                             'plt_latitude': '44'}}
 
@@ -135,7 +134,6 @@ class GeotagsTest(test.NoDBTestCase):
         expected = dict(body['geo_tag'])
         #(licostan): BIG NOTE, normalize server-name to compute_name
         #if we go por
-        expected.pop('compute_name')
         geo_tag_update_mock.assert_called_once_with(
                                         req.environ['nova.context'],
                                         obj['id'], expected)

--- a/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
+++ b/nova/tests/api/openstack/compute/contrib/test_geo_tags.py
@@ -1,0 +1,152 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import datetime
+import mock
+from webob import exc
+
+from nova.api.openstack.compute.contrib import geo_tags
+from nova import context
+from nova import exception
+from nova.objects import base
+from nova.objects import geo_tags as geo_tags_obj
+from nova import test
+
+
+class FakeRequest(object):
+    environ = {"nova.context": context.get_admin_context()}
+    GET = {}
+
+
+def fake_geotag_db(gt_id, server, state, latitude=None, longitude=None):
+    return {'server_name': server,
+            'valid_invalid': state,
+            'ip_address': None,
+            'mac_address': None,
+            'parent_mac': None,
+            'plt_latitude': latitude,
+            'plt_longitude': longitude,
+            'deleted': 0,
+            'deleted_at': datetime.datetime(2014, 9, 3),
+            'created_at': datetime.datetime(2014, 3, 3),
+            'updated_at': datetime.datetime(2014, 3, 4),
+            'rfid': None,
+            'alerts': 0,
+            'rfid_signature': None,
+            'id': gt_id
+            }
+
+
+class GeotagsTest(test.NoDBTestCase):
+    def setUp(self):
+        super(GeotagsTest, self).setUp()
+        self.controller = geo_tags.GeoTagsController()
+        self.context = context.get_admin_context()
+        self.db_list = (fake_geotag_db(1, 'server1', 'Valid', 100, 20),
+                        fake_geotag_db(2, 'server2', 'Invalid', 300, 100))
+
+        self.geo_tag_list = base.obj_make_list(context,
+            geo_tags_obj.GeoTagList(), geo_tags_obj.GeoTag, self.db_list)
+
+    @mock.patch('nova.db.geo_tag_get_all')
+    def test_geo_tags_empty(self, db_mock):
+        db_mock.return_value = {}
+        req = FakeRequest()
+        res_dict = self.controller.index(req)
+        response = {'geo_tags': []}
+        self.assertEqual(res_dict, response)
+        db_mock.assert_called_once_with(req.environ['nova.context'], {})
+
+    @mock.patch('nova.db.geo_tag_get_all')
+    def test_geo_tags(self, db_mock):
+        db_mock.return_value = self.db_list
+        req = FakeRequest()
+        res_dict = self.controller.index(req)
+        self.assertTrue(len(res_dict['geo_tags']), 2)
+        first_gt = res_dict['geo_tags'][0]
+        self.assertTrue(first_gt.server_name, self.db_list[0]['server_name'])
+        second_gt = res_dict['geo_tags'][1]
+        self.assertEquals(second_gt.server_name,
+                          self.db_list[1]['server_name'])
+        db_mock.assert_called_once_with(req.environ['nova.context'], {})
+
+    @mock.patch('nova.db.geo_tag_create')
+    @mock.patch('nova.compute.api.HostAPI._assert_host_exists')
+    def test_geo_tags_create(self, host_exists_mock, geo_tag_db_mock):
+        host_exists_mock.return_value = 'server3'
+        geo_tag_db_mock.return_value = fake_geotag_db(3, 'server3',
+                                                     'Active', 33, 44)
+        body = {'geo_tag': {'compute_name': 'server3',
+                            'valid_invalid': 'Valid',
+                            'plt_longitude': '33',
+                            'plt_latitude': '44'}}
+
+        req = FakeRequest()
+        res_dict = self.controller.create(req, body)
+        self.assertEquals(res_dict['geo_tag'].server_name, 'server3')
+        expected = dict(body['geo_tag'])
+        #(licostan): BIG NOTE, normalize server-name to compute_name
+        #if we go por
+        expected['server_name'] = expected.pop('compute_name')
+        geo_tag_db_mock.assert_called_once_with(req.environ['nova.context'],
+                                        expected)
+
+    @mock.patch('nova.compute.api.HostAPI._assert_host_exists')
+    def test_geo_tags_create_fails_invalid_host(self, host_exists_mock):
+        host = 'xxxserver3'
+        host_exists_mock.side_effect = exception.ComputeHostNotFound(host=host)
+        body = {'geo_tag': {'compute_name': host,
+                            'valid_invalid': 'Valid',
+                            'plt_longitude': '33',
+                            'plt_latitude': '44'}}
+
+        req = FakeRequest()
+        self.assertRaises(exc.HTTPNotFound, self.controller.create, req, body)
+
+    @mock.patch('nova.db.geo_tag_update')
+    @mock.patch('nova.db.geo_tag_get_by_node_name')
+    @mock.patch('nova.compute.api.HostAPI._assert_host_exists')
+    def test_geo_tags_update(self, host_exists_mock, geo_tag_get_mock,
+                             geo_tag_update_mock):
+        host_exists_mock.return_value = 'server4'
+        obj = fake_geotag_db(4, 'server4', 'Inactive', 11, 11)
+        geo_tag_get_mock.return_value = obj
+        geo_tag_update_mock.return_value = obj
+
+        body = {'geo_tag': {'compute_name': 'server4',
+                            'valid_invalid': 'Valid',
+                            'plt_longitude': '33',
+                            'plt_latitude': '44'}}
+
+        req = FakeRequest()
+        res_dict = self.controller.update(req, 'server4', body)
+        self.assertEquals(res_dict['geo_tag'].server_name, 'server4')
+        expected = dict(body['geo_tag'])
+        #(licostan): BIG NOTE, normalize server-name to compute_name
+        #if we go por
+        expected.pop('compute_name')
+        geo_tag_update_mock.assert_called_once_with(
+                                        req.environ['nova.context'],
+                                        obj['id'], expected)
+
+    @mock.patch('nova.db.geo_tag_destroy')
+    @mock.patch('nova.db.geo_tag_get_by_id_or_node_name')
+    def test_geo_tags_delete(self, geo_tag_get_mock, geo_tag_destroy_mock):
+        #(licostan): Why the get? just destroy?... TODO
+        obj = fake_geotag_db(4, 'server4', 'Inactive', 11, 11)
+        geo_tag_get_mock.return_value = obj
+        req = FakeRequest()
+        res_dict = self.controller.delete(req, 'server4')
+        geo_tag_destroy_mock.assert_called_once_with(
+                                        req.environ['nova.context'], obj['id'])

--- a/nova/tests/api/openstack/compute/contrib/test_instance_actions.py
+++ b/nova/tests/api/openstack/compute/contrib/test_instance_actions.py
@@ -78,7 +78,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -96,7 +96,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -118,7 +118,7 @@ class InstanceActionsTest(test.NoDBTestCase):
         def fake_get(self, context, instance_uuid):
             return {'uuid': instance_uuid}
 
-        def fake_instance_get_by_uuid(context, instance_id, use_slave=False):
+        def fake_instance_get_by_uuid(context, instance_id, use_subordinate=False):
             return {'name': 'fake', 'project_id': context.project_id}
 
         self.stubs.Set(compute_api.API, 'get', fake_get)

--- a/nova/tests/api/openstack/compute/contrib/test_security_groups.py
+++ b/nova/tests/api/openstack/compute/contrib/test_security_groups.py
@@ -80,7 +80,7 @@ def security_group_rule_db(rule, id=None):
 
 
 def return_server(context, server_id,
-                  columns_to_join=None, use_slave=False):
+                  columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': int(server_id),
            'power_state': 0x01,
@@ -91,7 +91,7 @@ def return_server(context, server_id,
 
 def return_server_by_uuid(context, server_uuid,
                           columns_to_join=None,
-                          use_slave=False):
+                          use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -360,7 +360,7 @@ class TestSecurityGroups(test.TestCase):
         expected = {'security_groups': groups}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
 
@@ -1639,7 +1639,7 @@ class SecurityGroupsOutputXmlTest(SecurityGroupsOutputTest):
             root.set('id')
             root.set('imageRef')
             root.set('flavorRef')
-            return xmlutil.MasterTemplate(root, 1,
+            return xmlutil.MainTemplate(root, 1,
                                           nsmap={None: xmlutil.XMLNS_V11})
 
     def _encode_body(self, body):

--- a/nova/tests/api/openstack/compute/contrib/test_server_start_stop.py
+++ b/nova/tests/api/openstack/compute/contrib/test_server_start_stop.py
@@ -25,7 +25,7 @@ from nova.tests.api.openstack import fakes
 
 
 def fake_instance_get(context, instance_id,
-                      columns_to_join=None, use_slave=False):
+                      columns_to_join=None, use_subordinate=False):
     result = fakes.stub_instance(id=1, uuid=instance_id)
     result['created_at'] = None
     result['deleted_at'] = None

--- a/nova/tests/api/openstack/compute/contrib/test_shelve.py
+++ b/nova/tests/api/openstack/compute/contrib/test_shelve.py
@@ -26,7 +26,7 @@ from nova.tests import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/nova/tests/api/openstack/compute/contrib/test_volumes.py
+++ b/nova/tests/api/openstack/compute/contrib/test_volumes.py
@@ -96,7 +96,7 @@ def fake_compute_volume_snapshot_create(self, context, volume_id,
     pass
 
 
-def fake_bdms_get_all_by_instance(context, instance_uuid, use_slave=False):
+def fake_bdms_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1,
              'instance_uuid': instance_uuid,

--- a/nova/tests/api/openstack/compute/plugins/v3/test_instance_actions.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_instance_actions.py
@@ -79,7 +79,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
         policy.set_rules(rules)
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -96,7 +96,7 @@ class InstanceActionsPolicyTest(test.NoDBTestCase):
         policy.set_rules(rules)
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -120,7 +120,7 @@ class InstanceActionsTest(test.NoDBTestCase):
             return {'uuid': instance_uuid}
 
         def fake_instance_get_by_uuid(context, instance_id,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})

--- a/nova/tests/api/openstack/compute/plugins/v3/test_server_actions.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_server_actions.py
@@ -466,7 +466,7 @@ class ServerActionsControllerTest(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stubs.Set(db, 'instance_get_by_uuid', server_not_found)
 
@@ -856,7 +856,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service.create(None, original_image)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -931,7 +931,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/api/openstack/compute/plugins/v3/test_server_metadata.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_server_metadata.py
@@ -89,7 +89,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -101,7 +101,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -575,7 +575,7 @@ class BadStateServerMetaDataTest(BaseTest):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/tests/api/openstack/compute/plugins/v3/test_servers.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_servers.py
@@ -107,7 +107,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 
@@ -689,7 +689,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
@@ -709,7 +709,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_no_admin_context(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotEqual(filters, None)
             self.assertEqual(filters['project_id'], 'fake')
@@ -725,7 +725,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_implies_all_tenants(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotEqual(filters, None)
             # The project_id assertion checks that the project_id
@@ -747,7 +747,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -764,7 +764,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
@@ -781,7 +781,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -798,7 +798,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
@@ -831,7 +831,7 @@ class ServersControllerTest(ControllerTest):
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
@@ -849,7 +849,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False,
+                         columns_to_join=None, use_subordinate=False,
                          expected_attrs=[]):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)

--- a/nova/tests/api/openstack/compute/plugins/v3/test_shelve.py
+++ b/nova/tests/api/openstack/compute/plugins/v3/test_shelve.py
@@ -26,7 +26,7 @@ from nova.tests import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/nova/tests/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/api/openstack/compute/test_server_actions.py
@@ -631,7 +631,7 @@ class ServerActionsControllerTest(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stubs.Set(db, 'instance_get_by_uuid', server_not_found)
 
@@ -1022,7 +1022,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service.create(None, original_image)
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1097,7 +1097,7 @@ class ServerActionsControllerTest(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/nova/tests/api/openstack/compute/test_server_metadata.py
+++ b/nova/tests/api/openstack/compute/test_server_metadata.py
@@ -90,7 +90,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -102,7 +102,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -568,7 +568,7 @@ class BadStateServerMetaDataTest(BaseTest):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/nova/tests/api/openstack/compute/test_servers.py
+++ b/nova/tests/api/openstack/compute/test_servers.py
@@ -659,7 +659,7 @@ class ServersControllerTest(ControllerTest):
     def test_tenant_id_filter_converts_to_project_id_for_admin(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'newfake')
             self.assertFalse(filters.get('tenant_id'))
@@ -678,7 +678,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_normal(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -694,7 +694,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_one(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]
 
@@ -710,7 +710,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_zero(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -726,7 +726,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_param_false(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertNotIn('all_tenants', filters)
             return [fakes.stub_instance(100)]
 
@@ -757,7 +757,7 @@ class ServersControllerTest(ControllerTest):
     def test_admin_restricted_tenant(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertEqual(filters['project_id'], 'fake')
             return [fakes.stub_instance(100)]
@@ -774,7 +774,7 @@ class ServersControllerTest(ControllerTest):
     def test_all_tenants_pass_policy(self):
         def fake_get_all(context, filters=None, sort_key=None,
                          sort_dir='desc', limit=None, marker=None,
-                         columns_to_join=None, use_slave=False):
+                         columns_to_join=None, use_subordinate=False):
             self.assertIsNotNone(filters)
             self.assertNotIn('project_id', filters)
             return [fakes.stub_instance(100)]

--- a/nova/tests/api/openstack/fakes.py
+++ b/nova/tests/api/openstack/fakes.py
@@ -440,7 +440,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         return stub_instance(1, **kwargs)
     return _return_server
 
@@ -463,8 +463,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         for i in xrange(num_servers):
             uuid = get_fake_uuid(i)
@@ -711,7 +711,7 @@ def stub_snapshot_get_all(self, context):
             stub_snapshot(102, project_id='superduperfake')]
 
 
-def stub_bdm_get_all_by_instance(context, instance_uuid, use_slave=False):
+def stub_bdm_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1, 'source_type': 'volume', 'destination_type': 'volume',
             'volume_id': 'volume_id1', 'instance_uuid': instance_uuid}),

--- a/nova/tests/api/openstack/test_xmlutil.py
+++ b/nova/tests/api/openstack/test_xmlutil.py
@@ -391,17 +391,17 @@ class TemplateElementTest(test.NoDBTestCase):
                      attr2=xmlutil.ConstantSelector(2),
                      attr3=xmlutil.ConstantSelector(3))
 
-        # Create a master template element
-        master_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
+        # Create a main template element
+        main_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
 
-        # Create a couple of slave template element
-        slave_elems = [
+        # Create a couple of subordinate template element
+        subordinate_elems = [
             xmlutil.TemplateElement('test', attr2=attrs['attr2']),
             xmlutil.TemplateElement('test', attr3=attrs['attr3']),
             ]
 
         # Try the render
-        elem = master_elem._render(None, None, slave_elems, None)
+        elem = main_elem._render(None, None, subordinate_elems, None)
 
         # Verify the particulars of the render
         self.assertEqual(elem.tag, 'test')
@@ -413,7 +413,7 @@ class TemplateElementTest(test.NoDBTestCase):
         parent = etree.Element('parent')
 
         # Try the render again...
-        elem = master_elem._render(parent, None, slave_elems, dict(a='foo'))
+        elem = main_elem._render(parent, None, subordinate_elems, dict(a='foo'))
 
         # Verify the particulars of the render
         self.assertEqual(len(parent), 1)
@@ -550,47 +550,47 @@ class TemplateTest(test.NoDBTestCase):
         self.assertEqual(len(nsmap), 1)
         self.assertEqual(nsmap['a'], 'foo')
 
-    def test_master_attach(self):
-        # Set up a master template
+    def test_main_attach(self):
+        # Set up a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1)
+        tmpl = xmlutil.MainTemplate(elem, 1)
 
-        # Make sure it has a root but no slaves
+        # Make sure it has a root but no subordinates
         self.assertEqual(tmpl.root, elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
         self.assertTrue(repr(tmpl))
 
-        # Try to attach an invalid slave
+        # Try to attach an invalid subordinate
         bad_elem = xmlutil.TemplateElement('test2')
         self.assertRaises(ValueError, tmpl.attach, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
-        # Try to attach an invalid and a valid slave
+        # Try to attach an invalid and a valid subordinate
         good_elem = xmlutil.TemplateElement('test')
         self.assertRaises(ValueError, tmpl.attach, good_elem, bad_elem)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Try to attach an inapplicable template
         class InapplicableTemplate(xmlutil.Template):
-            def apply(self, master):
+            def apply(self, main):
                 return False
         inapp_tmpl = InapplicableTemplate(good_elem)
         tmpl.attach(inapp_tmpl)
-        self.assertEqual(len(tmpl.slaves), 0)
+        self.assertEqual(len(tmpl.subordinates), 0)
 
         # Now try attaching an applicable template
         tmpl.attach(good_elem)
-        self.assertEqual(len(tmpl.slaves), 1)
-        self.assertEqual(tmpl.slaves[0].root, good_elem)
+        self.assertEqual(len(tmpl.subordinates), 1)
+        self.assertEqual(tmpl.subordinates[0].root, good_elem)
 
-    def test_master_copy(self):
-        # Construct a master template
+    def test_main_copy(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1, nsmap=dict(a='foo'))
+        tmpl = xmlutil.MainTemplate(elem, 1, nsmap=dict(a='foo'))
 
-        # Give it a slave
-        slave = xmlutil.TemplateElement('test')
-        tmpl.attach(slave)
+        # Give it a subordinate
+        subordinate = xmlutil.TemplateElement('test')
+        tmpl.attach(subordinate)
 
         # Construct a copy
         copy = tmpl.copy()
@@ -600,43 +600,43 @@ class TemplateTest(test.NoDBTestCase):
         self.assertEqual(tmpl.root, copy.root)
         self.assertEqual(tmpl.version, copy.version)
         self.assertEqual(id(tmpl.nsmap), id(copy.nsmap))
-        self.assertNotEqual(id(tmpl.slaves), id(copy.slaves))
-        self.assertEqual(len(tmpl.slaves), len(copy.slaves))
-        self.assertEqual(tmpl.slaves[0], copy.slaves[0])
+        self.assertNotEqual(id(tmpl.subordinates), id(copy.subordinates))
+        self.assertEqual(len(tmpl.subordinates), len(copy.subordinates))
+        self.assertEqual(tmpl.subordinates[0], copy.subordinates[0])
 
-    def test_slave_apply(self):
-        # Construct a master template
+    def test_subordinate_apply(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        master = xmlutil.MasterTemplate(elem, 3)
+        main = xmlutil.MainTemplate(elem, 3)
 
-        # Construct a slave template with applicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 2)
-        self.assertEqual(slave.apply(master), True)
-        self.assertTrue(repr(slave))
+        # Construct a subordinate template with applicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 2)
+        self.assertEqual(subordinate.apply(main), True)
+        self.assertTrue(repr(subordinate))
 
-        # Construct a slave template with equal minimum version
-        slave = xmlutil.SlaveTemplate(elem, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with equal minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with inapplicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 4)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with inapplicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 4)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with applicable version range
-        slave = xmlutil.SlaveTemplate(elem, 2, 4)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with applicable version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 2, 4)
+        self.assertEqual(subordinate.apply(main), True)
 
-        # Construct a slave template with low version range
-        slave = xmlutil.SlaveTemplate(elem, 1, 2)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with low version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 1, 2)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with high version range
-        slave = xmlutil.SlaveTemplate(elem, 4, 5)
-        self.assertEqual(slave.apply(master), False)
+        # Construct a subordinate template with high version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 4, 5)
+        self.assertEqual(subordinate.apply(main), False)
 
-        # Construct a slave template with matching version range
-        slave = xmlutil.SlaveTemplate(elem, 3, 3)
-        self.assertEqual(slave.apply(master), True)
+        # Construct a subordinate template with matching version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 3, 3)
+        self.assertEqual(subordinate.apply(main), True)
 
     def test__serialize(self):
         # Our test object to serialize
@@ -657,7 +657,7 @@ class TemplateTest(test.NoDBTestCase):
                 },
             }
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
         value = xmlutil.SubTemplateElement(root, 'value', selector='values')
@@ -665,22 +665,22 @@ class TemplateTest(test.NoDBTestCase):
         attrs = xmlutil.SubTemplateElement(root, 'attrs', selector='attrs')
         xmlutil.SubTemplateElement(attrs, 'attr', selector=xmlutil.get_items,
                                    key=0, value=1)
-        master = xmlutil.MasterTemplate(root, 1, nsmap=dict(f='foo'))
+        main = xmlutil.MainTemplate(root, 1, nsmap=dict(f='foo'))
 
-        # Set up our slave template
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        # Set up our subordinate template
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image', id='id')
         image.text = xmlutil.Selector('name')
-        slave = xmlutil.SlaveTemplate(root_slave, 1, nsmap=dict(b='bar'))
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1, nsmap=dict(b='bar'))
 
-        # Attach the slave to the master...
-        master.attach(slave)
+        # Attach the subordinate to the main...
+        main.attach(subordinate)
 
         # Try serializing our object
-        siblings = master._siblings()
-        nsmap = master._nsmap()
-        result = master._serialize(None, obj, siblings, nsmap)
+        siblings = main._siblings()
+        nsmap = main._nsmap()
+        result = main._serialize(None, obj, siblings, nsmap)
 
         # Now we get to manually walk the element tree...
         self.assertEqual(result.tag, 'test')
@@ -712,14 +712,14 @@ class TemplateTest(test.NoDBTestCase):
         expected_xml = (("<?xml version='1.0' encoding='UTF-8'?>\n"
                     '<extra_specs><foo:bar xmlns:foo="foo">999</foo:bar>'
                     '</extra_specs>'))
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('extra_specs', selector='extra_specs',
                                        colon_ns=True)
         value = xmlutil.SubTemplateElement(root, 'foo:bar', selector='foo:bar',
                                            colon_ns=True)
         value.text = xmlutil.Selector()
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test__serialize_with_empty_datum_selector(self):
@@ -733,76 +733,76 @@ class TemplateTest(test.NoDBTestCase):
 
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
-        master = xmlutil.MasterTemplate(root, 1)
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        main = xmlutil.MainTemplate(root, 1)
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image')
         image.set('id')
         xmlutil.make_links(image, 'links')
-        slave = xmlutil.SlaveTemplate(root_slave, 1)
-        master.attach(slave)
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1)
+        main.attach(subordinate)
 
-        siblings = master._siblings()
-        result = master._serialize(None, obj, siblings)
+        siblings = main._siblings()
+        result = main._serialize(None, obj, siblings)
         self.assertEqual(result.tag, 'test')
         self.assertEqual(result[0].tag, 'image')
         self.assertEqual(result[0].get('id'), str(obj['test']['image']))
 
 
-class MasterTemplateBuilder(xmlutil.TemplateBuilder):
+class MainTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.MasterTemplate(elem, 1)
+        return xmlutil.MainTemplate(elem, 1)
 
 
-class SlaveTemplateBuilder(xmlutil.TemplateBuilder):
+class SubordinateTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.SlaveTemplate(elem, 1)
+        return xmlutil.SubordinateTemplate(elem, 1)
 
 
 class TemplateBuilderTest(test.NoDBTestCase):
-    def test_master_template_builder(self):
+    def test_main_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNone(MainTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = MasterTemplateBuilder()
+        tmpl1 = MainTemplateBuilder()
 
         # Make sure that there is a template cached...
-        self.assertIsNotNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNotNone(MainTemplateBuilder._tmpl)
 
         # Make sure it wasn't what was returned...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, tmpl1)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        cached = MasterTemplateBuilder._tmpl
-        tmpl2 = MasterTemplateBuilder()
-        self.assertEqual(MasterTemplateBuilder._tmpl, cached)
+        cached = MainTemplateBuilder._tmpl
+        tmpl2 = MainTemplateBuilder()
+        self.assertEqual(MainTemplateBuilder._tmpl, cached)
 
         # Make sure we're always getting fresh copies
         self.assertNotEqual(tmpl1, tmpl2)
 
         # Make sure we can override the copying behavior
-        tmpl3 = MasterTemplateBuilder(False)
-        self.assertEqual(MasterTemplateBuilder._tmpl, tmpl3)
+        tmpl3 = MainTemplateBuilder(False)
+        self.assertEqual(MainTemplateBuilder._tmpl, tmpl3)
 
-    def test_slave_template_builder(self):
+    def test_subordinate_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNone(SubordinateTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = SlaveTemplateBuilder()
+        tmpl1 = SubordinateTemplateBuilder()
 
         # Make sure there is a template cached...
-        self.assertIsNotNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNotNone(SubordinateTemplateBuilder._tmpl)
 
         # Make sure it was what was returned...
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        tmpl2 = SlaveTemplateBuilder()
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        tmpl2 = SubordinateTemplateBuilder()
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure we're always getting the cached copy
         self.assertEqual(tmpl1, tmpl2)
@@ -828,7 +828,7 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         expected_xml = ("<?xml version='1.0' encoding='UTF-8'?>\n"
                         '<wrapper><a>foo</a><b>bar</b></wrapper>')
         root = xmlutil.make_flat_dict('wrapper')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(result, expected_xml)
 
@@ -836,7 +836,7 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
 '<ns0:wrapper xmlns:ns0="ns"><ns0:a>foo</ns0:a><ns0:b>bar</ns0:b>'
 "</ns0:wrapper>")
         root = xmlutil.make_flat_dict('wrapper', ns='ns')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo', b='bar')))
         self.assertEqual(result, expected_xml)
 
@@ -846,10 +846,10 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         expected_xml = (("<?xml version='1.0' encoding='UTF-8'?>\n"
                     '<extra_specs><foo:bar xmlns:foo="foo">999</foo:bar>'
                     '</extra_specs>'))
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.make_flat_dict('extra_specs', colon_ns=True)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_make_flat_dict_with_parent(self):
@@ -866,8 +866,8 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
         root.set('id')
         extra = xmlutil.make_flat_dict('extra_info', root=root)
         root.append(extra)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_make_flat_dict_with_dicts(self):
@@ -884,8 +884,8 @@ class MiscellaneousXMLUtilTests(test.NoDBTestCase):
                                       ignore_sub_dicts=True)
         extra = xmlutil.make_flat_dict('extra_info', selector='extra_info')
         root.append(extra)
-        master = xmlutil.MasterTemplate(root, 1)
-        result = master.serialize(obj)
+        main = xmlutil.MainTemplate(root, 1)
+        result = main.serialize(obj)
         self.assertEqual(expected_xml, result)
 
     def test_safe_parse_xml(self):

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -595,7 +595,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         time.time().AndReturn(21)
         instance_obj.InstanceList.get_by_host(ctxt,
                            'fake-mini',
-                           use_slave=True).AndReturn([])
+                           use_subordinate=True).AndReturn([])
         self.compute.driver.get_all_bw_counters([]).AndRaise(
             NotImplementedError)
         self.mox.ReplayAll()
@@ -5614,9 +5614,9 @@ class ComputeTestCase(BaseTestCase):
         self.compute._shutdown_instance(ctxt, inst1, bdms, notify=False).\
                                         AndRaise(test.TestingException)
         block_device_obj.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst1.uuid, use_slave=True).AndReturn(bdms)
+                inst1.uuid, use_subordinate=True).AndReturn(bdms)
         block_device_obj.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst2.uuid, use_slave=True).AndReturn(bdms)
+                inst2.uuid, use_subordinate=True).AndReturn(bdms)
         self.compute._shutdown_instance(ctxt, inst2, bdms, notify=False).\
                                         AndReturn(None)
 
@@ -5721,7 +5721,7 @@ class ComputeTestCase(BaseTestCase):
         db.instance_get_by_uuid(self.context, fake_inst['uuid'],
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.compute.network_api.get_instance_nw_info(self.context,
                 mox.IsA(instance_obj.Instance)).AndReturn(fake_nw_info)
@@ -5752,13 +5752,13 @@ class ComputeTestCase(BaseTestCase):
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -5766,7 +5766,7 @@ class ComputeTestCase(BaseTestCase):
             return instance_map[instance_uuid]
 
         # NOTE(comstud): Override the stub in setUp()
-        def fake_get_instance_nw_info(context, instance, use_slave=False):
+        def fake_get_instance_nw_info(context, instance, use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -5840,7 +5840,7 @@ class ComputeTestCase(BaseTestCase):
         unrescued_instances = {'fake_uuid1': False, 'fake_uuid2': False}
 
         def fake_instance_get_all_by_filters(context, filters,
-                                             columns_to_join, use_slave=False):
+                                             columns_to_join, use_subordinate=False):
             self.assertEqual(columns_to_join, ["system_metadata"])
             return instances
 
@@ -5899,7 +5899,7 @@ class ComputeTestCase(BaseTestCase):
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for uuid 'noexist'
@@ -5910,7 +5910,7 @@ class ComputeTestCase(BaseTestCase):
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -6032,7 +6032,7 @@ class ComputeTestCase(BaseTestCase):
                                             sort_dir,
                                             marker=None,
                                             columns_to_join=[],
-                                            use_slave=True,
+                                            use_subordinate=True,
                                             limit=None)
             self.assertThat(conductor_instance_update.mock_calls,
                             testtools_matchers.HasLength(len(old_instances)))
@@ -6386,7 +6386,7 @@ class ComputeTestCase(BaseTestCase):
         instance_obj.InstanceList.get_by_filters(
             ctxt, mox.IgnoreArg(),
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True
+            use_subordinate=True
             ).AndReturn(instances)
 
         # The first instance delete fails.
@@ -6426,12 +6426,12 @@ class ComputeTestCase(BaseTestCase):
             {'state': power_state.RUNNING})
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.RUNNING,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.compute.driver.get_info(mox.IgnoreArg()).AndReturn(
             {'state': power_state.SHUTDOWN})
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.SHUTDOWN,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.mox.ReplayAll()
         self.compute._sync_power_states(ctxt)
 
@@ -7362,7 +7362,7 @@ class ComputeAPITestCase(BaseTestCase):
                 instance_obj.INSTANCE_DEFAULT_FIELDS + ['fault']))
 
         def fake_db_get(_context, _instance_uuid,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
             return exp_instance
 
         self.stubs.Set(db, 'instance_get_by_uuid', fake_db_get)
@@ -7383,7 +7383,7 @@ class ComputeAPITestCase(BaseTestCase):
                 instance_obj.INSTANCE_DEFAULT_FIELDS + ['fault']))
 
         def fake_db_get(context, instance_uuid,
-                        columns_to_join=None, use_slave=False):
+                        columns_to_join=None, use_subordinate=False):
             return exp_instance
 
         self.stubs.Set(db, 'instance_get_by_uuid', fake_db_get)
@@ -9683,7 +9683,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-                aggregate=jsonutils.to_primitive(self.aggr), slave_info=None)
+                aggregate=jsonutils.to_primitive(self.aggr), subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -9697,36 +9697,36 @@ class ComputeAggrTestCase(BaseTestCase):
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="host",
-                slave_info=None)
+                subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-                slave_info="SLAVE_INFO",
+                subordinate_info="SLAVE_INFO",
                 aggregate=jsonutils.to_primitive(self.aggr))
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="the_host",
-                slave_info="SLAVE_INFO")
+                subordinate_info="SLAVE_INFO")
 
 
 class ComputePolicyTestCase(BaseTestCase):

--- a/nova/tests/compute/test_compute_api.py
+++ b/nova/tests/compute/test_compute_api.py
@@ -670,7 +670,7 @@ class _ComputeAPIUnitTestMixIn(object):
 
         db.block_device_mapping_get_all_by_instance(self.context,
                                                  inst.uuid,
-                                                 use_slave=False).AndReturn([])
+                                                 use_subordinate=False).AndReturn([])
         inst.save()
         self.compute_api._create_reservations(self.context,
                                               inst, inst.instance_type_id,
@@ -774,7 +774,7 @@ class _ComputeAPIUnitTestMixIn(object):
         timeutils.set_time_override(delete_time)
 
         db.block_device_mapping_get_all_by_instance(
-            self.context, inst.uuid, use_slave=False).AndReturn([])
+            self.context, inst.uuid, use_subordinate=False).AndReturn([])
         inst.save().AndRaise(test.TestingException)
 
         self.mox.ReplayAll()
@@ -1531,7 +1531,7 @@ class _ComputeAPIUnitTestMixIn(object):
             'is_public': False
         }
 
-        def fake_get_all_by_instance(context, instance, use_slave=False):
+        def fake_get_all_by_instance(context, instance, use_subordinate=False):
             return copy.deepcopy(instance_bdms)
 
         def fake_image_create(context, image_meta, data):

--- a/nova/tests/compute/test_compute_mgr.py
+++ b/nova/tests/compute/test_compute_mgr.py
@@ -166,7 +166,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             context.get_admin_context().AndReturn(fake_context)
             db.instance_get_all_by_host(
                     fake_context, our_host, columns_to_join=['info_cache'],
-                    use_slave=False
+                    use_subordinate=False
                     ).AndReturn(startup_instances)
             if defer_iptables_apply:
                 self.compute.driver.filter_defer_apply_on()
@@ -248,7 +248,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         context.get_admin_context().AndReturn(fake_context)
         db.instance_get_all_by_host(fake_context, our_host,
                                     columns_to_join=['info_cache'],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([])
         self.compute.init_virt_events()
 
@@ -600,7 +600,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                           inst in driver_instances]},
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(
+                use_subordinate=True).AndReturn(
                         driver_instances)
 
         self.mox.ReplayAll()
@@ -641,7 +641,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                 fake_context, filters,
                 'created_at', 'desc', columns_to_join=None,
                 limit=None, marker=None,
-                use_slave=True).AndReturn(all_instances)
+                use_subordinate=True).AndReturn(all_instances)
 
         self.mox.ReplayAll()
 
@@ -683,7 +683,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_match(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
@@ -691,7 +691,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_running_stopped(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
@@ -701,7 +701,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def _test_sync_to_stop(self, power_state, vm_state, driver_power_state,
                            stop=True, force=False):
         instance = self._get_sync_instance(power_state, vm_state)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.StubOutWithMock(self.compute.compute_api, 'stop')
         self.mox.StubOutWithMock(self.compute.compute_api, 'force_stop')

--- a/nova/tests/compute/test_compute_utils.py
+++ b/nova/tests/compute/test_compute_utils.py
@@ -73,7 +73,7 @@ class ComputeValidateDeviceTestCase(test.TestCase):
         self.data = []
 
         self.stubs.Set(db, 'block_device_mapping_get_all_by_instance',
-                       lambda context, instance, use_slave=False: self.data)
+                       lambda context, instance, use_subordinate=False: self.data)
 
     def _update_flavor(self, flavor_info):
         self.flavor = {

--- a/nova/tests/compute/test_compute_xen.py
+++ b/nova/tests/compute/test_compute_xen.py
@@ -51,7 +51,7 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
         self.mox.StubOutWithMock(self.compute, '_sync_instance_power_state')
 
         instance_obj.InstanceList.get_by_host(ctxt,
-                self.compute.host, use_slave=True).AndReturn(instance_list)
+                self.compute.host, use_subordinate=True).AndReturn(instance_list)
         self.compute.driver.get_num_instances().AndReturn(1)
         vm_utils.lookup(self.compute.driver._session, instance['name'],
                 False).AndReturn(None)

--- a/nova/tests/compute/test_rpcapi.py
+++ b/nova/tests/compute/test_rpcapi.py
@@ -102,13 +102,13 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
         # NOTE(russellb) Havana compat
         self.flags(compute='havana', group='upgrade_levels')
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={}, version='2.14')
+                subordinate_info={}, version='2.14')
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -538,13 +538,13 @@ class ComputeRpcAPITestCase(test.TestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
         # NOTE(russellb) Havana compat
         self.flags(compute='havana', group='upgrade_levels')
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={}, version='2.15')
+                subordinate_info={}, version='2.15')
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/nova/tests/conductor/test_conductor.py
+++ b/nova/tests/conductor/test_conductor.py
@@ -616,21 +616,21 @@ class ConductorTestCase(_BaseTestCase, test.TestCase):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=False)
+                                       columns_to_join=None, use_subordinate=False)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort')
 
-    def test_instance_get_all_by_filters_use_slave(self):
+    def test_instance_get_all_by_filters_use_subordinate(self):
         filters = {'foo': 'bar'}
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=True)
+                                       columns_to_join=None, use_subordinate=True)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
-                                                   use_slave=True)
+                                                   use_subordinate=True)
 
     def test_instance_get_all_by_host(self):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
@@ -877,21 +877,21 @@ class ConductorRPCAPITestCase(_BaseTestCase, test.TestCase):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=False)
+                                       columns_to_join=None, use_subordinate=False)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort')
 
-    def test_instance_get_all_by_filters_use_slave(self):
+    def test_instance_get_all_by_filters_use_subordinate(self):
         filters = {'foo': 'bar'}
         self.mox.StubOutWithMock(db, 'instance_get_all_by_filters')
         db.instance_get_all_by_filters(self.context, filters,
                                        'fake-key', 'fake-sort',
-                                       columns_to_join=None, use_slave=True)
+                                       columns_to_join=None, use_subordinate=True)
         self.mox.ReplayAll()
         self.conductor.instance_get_all_by_filters(self.context, filters,
                                                    'fake-key', 'fake-sort',
-                                                   use_slave=True)
+                                                   use_subordinate=True)
 
     def _test_stubbed(self, name, dbargs, condargs,
                       db_result_listified=False, db_exception=None):

--- a/nova/tests/db/test_db_api.py
+++ b/nova/tests/db/test_db_api.py
@@ -1215,8 +1215,8 @@ class SecurityGroupTestCase(test.TestCase, ModelsObjectComparatorMixin):
 
         session = get_session()
         self.mox.StubOutWithMock(sqlalchemy_api, 'get_session')
-        sqlalchemy_api.get_session(use_slave=False).AndReturn(session)
-        sqlalchemy_api.get_session(use_slave=False).AndReturn(session)
+        sqlalchemy_api.get_session(use_subordinate=False).AndReturn(session)
+        sqlalchemy_api.get_session(use_subordinate=False).AndReturn(session)
         self.mox.ReplayAll()
 
         security_group = db.security_group_get(self.ctxt, sid,

--- a/nova/tests/integrated/test_api_samples.py
+++ b/nova/tests/integrated/test_api_samples.py
@@ -3797,7 +3797,7 @@ class VolumeAttachmentsSampleBase(ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/tests/integrated/v3/test_extended_volumes.py
+++ b/nova/tests/integrated/v3/test_extended_volumes.py
@@ -31,7 +31,7 @@ class ExtendedVolumesSampleJsonTests(test_servers.ServersSampleBase):
     def _stub_compute_api_get_instance_bdms(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/nova/tests/network/test_linux_net.py
+++ b/nova/tests/network/test_linux_net.py
@@ -259,7 +259,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/nova/tests/network/test_manager.py
+++ b/nova/tests/network/test_manager.py
@@ -420,7 +420,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -473,7 +473,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -570,7 +570,7 @@ class FlatNetworkTestCase(test.TestCase):
 
         inst = fake_inst(display_name=HOST, uuid=FAKEUUID)
         db.instance_get_by_uuid(self.context,
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(inst)
@@ -703,7 +703,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -751,7 +751,7 @@ class VlanNetworkTestCase(test.TestCase):
         db.virtual_interface_get_by_instance_and_network(mox.IgnoreArg(),
                 mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(vifs[0])
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -1318,7 +1318,7 @@ class VlanNetworkTestCase(test.TestCase):
                        ).AndReturn(dict(test_network.fake_network,
                                         **networks[0]))
         db.instance_get_by_uuid(mox.IgnoreArg(),
-                                mox.IgnoreArg(), use_slave=False,
+                                mox.IgnoreArg(), use_subordinate=False,
                                 columns_to_join=['info_cache',
                                                  'security_groups']
                                 ).AndReturn(fake_inst(display_name=HOST,
@@ -1602,7 +1602,7 @@ class CommonNetworkTestCase(test.TestCase):
                                  'virtual_interface_get_by_instance')
         manager.db.virtual_interface_get_by_instance(
                 self.context, FAKEUUID,
-                use_slave=False).AndRaise(exception.InstanceNotFound(
+                use_subordinate=False).AndRaise(exception.InstanceNotFound(
                                                  instance_id=FAKEUUID))
         self.mox.ReplayAll()
         self.assertRaises(messaging.ExpectedException,

--- a/nova/tests/objects/test_geo_tags.py
+++ b/nova/tests/objects/test_geo_tags.py
@@ -20,8 +20,6 @@ from nova.tests.objects import test_objects
 
 NOW = timeutils.utcnow().replace(microsecond=0)
 
-#(licostan): TODO - add GeoTagsList test
-
 
 def fake_db_geo_tag(**updates):
     db_instance = {

--- a/nova/tests/objects/test_geo_tags.py
+++ b/nova/tests/objects/test_geo_tags.py
@@ -1,0 +1,114 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from nova import context
+from nova.objects import geo_tags
+from nova.openstack.common import timeutils
+from nova.tests.objects import test_objects
+
+
+NOW = timeutils.utcnow().replace(microsecond=0)
+
+#(licostan): TODO - add GeoTagsList test
+
+
+def fake_db_geo_tag(**updates):
+    db_instance = {
+            'server_name': 'server',
+            'valid_invalid': 'Valid',
+            'ip_address': None,
+            'mac_address': None,
+            'parent_mac': None,
+            'plt_latitude': '12.22',
+            'plt_longitude': '13.33',
+            'deleted': 0,
+            'deleted_at': NOW,
+            'created_at': NOW,
+            'updated_at': NOW,
+            'rfid': None,
+            'alerts': 0,
+            'rfid_signature': None,
+            'id': 1
+            }
+
+    if updates:
+        db_instance.update(updates)
+    return db_instance
+
+
+class _TestGeoTagObject(object):
+
+    @mock.patch('nova.db.geo_tag_get_by_id')
+    def test_get_by_id(self, db_mock):
+        ctxt = context.get_admin_context()
+        fake_tag = fake_db_geo_tag()
+        db_mock.return_value = fake_tag
+        tag = geo_tags.GeoTag.get_by_id(ctxt, fake_tag['id'])
+        self.compare_obj(tag, fake_tag)
+        db_mock.assert_called_once_with(ctxt, fake_tag['id'])
+
+    @mock.patch('nova.db.geo_tag_get_by_node_name')
+    def test_get_by_id(self, db_mock):
+        ctxt = context.get_admin_context()
+        fake_tag = fake_db_geo_tag()
+        db_mock.return_value = fake_tag
+        tag = geo_tags.GeoTag.get_by_node_name(ctxt, fake_tag['server_name'])
+        self.compare_obj(tag, fake_tag)
+        db_mock.assert_called_once_with(ctxt, fake_tag['server_name'])
+
+    @mock.patch('nova.db.geo_tag_create')
+    def test_create(self, db_mock):
+        ctxt = context.get_admin_context()
+        fake_tag = fake_db_geo_tag()
+        db_mock.return_value = fake_tag
+        gt = geo_tags.GeoTag()
+        gt.server_name = 'TestServer'
+        gt.valid_invalid = 'Valid'
+        gt.create(ctxt)
+        db_mock.assert_called_once_with(ctxt, {'server_name': 'TestServer',
+                                               'valid_invalid': 'Valid'})
+
+    @mock.patch('nova.db.geo_tag_update')
+    def test_save(self, db_mock):
+        ctxt = context.get_admin_context()
+        fake_tag = fake_db_geo_tag()
+        db_mock.return_value = fake_tag
+        gt = geo_tags.GeoTag()
+        gt.id = 22
+        gt.server_name = 'TestServer'
+        gt.valid_invalid = 'Valid'
+        gt.save(ctxt)
+        db_mock.assert_called_once_with(ctxt, 22,
+                                        {'server_name': 'TestServer',
+                                         'valid_invalid': 'Valid'})
+
+    @mock.patch('nova.db.geo_tag_destroy')
+    def test_delete(self, db_mock):
+        ctxt = context.get_admin_context()
+        fake_tag = fake_db_geo_tag()
+        db_mock.return_value = fake_tag
+        gt = geo_tags.GeoTag()
+        gt.id = 22
+        gt.destroy(ctxt)
+        db_mock.assert_called_once_with(ctxt, 22)
+
+
+class TestGeoTagsObject(test_objects._LocalTest,
+                          _TestGeoTagObject):
+    pass
+
+
+class TestRemoteGeoTagsObject(test_objects._RemoteTest,
+                                _TestGeoTagObject):
+    pass

--- a/nova/tests/objects/test_instance.py
+++ b/nova/tests/objects/test_instance.py
@@ -104,7 +104,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, 'uuid',
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'uuid',
@@ -123,7 +123,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(
             self.context, 'uuid',
             columns_to_join=exp_cols,
-            use_slave=False
+            use_subordinate=False
             ).AndReturn(self.fake_instance)
         fake_faults = test_instance_fault.fake_faults
         db.instance_fault_get_by_instance_uuids(
@@ -155,13 +155,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         fake_inst2 = dict(self.fake_instance,
                           system_metadata=[{'key': 'foo', 'value': 'bar'}])
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['system_metadata'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst2)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -186,7 +186,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, 'fake-uuid',
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_instance)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, 'fake-uuid')
@@ -204,13 +204,13 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='orig-host'))
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(dict(self.fake_instance,
                                                  host='new-host'))
         self.mox.StubOutWithMock(instance_info_cache.InstanceInfoCache,
@@ -232,7 +232,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(instance.Instance, 'get_by_uuid')
         instance.Instance.get_by_uuid(self.context, uuid=inst.uuid,
                                       expected_attrs=['metadata'],
-                                      use_slave=False
+                                      use_subordinate=False
                                       ).AndReturn(inst_copy)
         self.mox.ReplayAll()
         self.assertRaises(exception.OrphanedObjectError, inst.refresh)
@@ -279,7 +279,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates,
@@ -359,7 +359,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(old_ref)
         db.instance_update_and_get_original(
                 self.context, fake_uuid, expected_updates, update_cells=False,
@@ -372,7 +372,7 @@ class _TestInstanceObject(object):
         self.mox.ReplayAll()
 
         inst = instance.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                             use_slave=False)
+                                             use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -386,7 +386,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -400,7 +400,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -414,7 +414,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -438,7 +438,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.instance_info_cache_update(self.context, fake_uuid,
                                       {'network_info': nwinfo2_json})
@@ -455,7 +455,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -481,7 +481,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         db.security_group_update(self.context, 1, {'description': 'changed'}
                                  ).AndReturn(fake_inst['security_groups'][0])
@@ -506,7 +506,7 @@ class _TestInstanceObject(object):
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid)
@@ -518,7 +518,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -564,7 +564,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_by_uuid')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=['pci_devices'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         self.mox.ReplayAll()
         inst = instance.Instance.get_by_uuid(self.context, fake_uuid,
@@ -582,7 +582,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_by_uuid(self.context, fake_uuid,
                                 columns_to_join=[],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(self.fake_instance)
         db.instance_fault_get_by_instance_uuids(
             self.context, [fake_uuid]).AndReturn({fake_uuid: fake_faults})
@@ -874,11 +874,11 @@ class _TestInstanceListObject(object):
         db.instance_get_all_by_filters(self.context, {'foo': 'bar'}, 'uuid',
                                        'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(fakes)
+                                       use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -895,12 +895,12 @@ class _TestInstanceListObject(object):
                                        {'deleted': True, 'cleaned': False},
                                        'uuid', 'asc', limit=None, marker=None,
                                        columns_to_join=['metadata'],
-                                       use_slave=False).AndReturn(
+                                       use_subordinate=False).AndReturn(
                                            [fakes[1]])
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -913,7 +913,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_get_all_by_host')
         db.instance_get_all_by_host(self.context, 'foo',
                                     columns_to_join=None,
-                                    use_slave=False).AndReturn(fakes)
+                                    use_subordinate=False).AndReturn(fakes)
         self.mox.ReplayAll()
         inst_list = instance.InstanceList.get_by_host(self.context, 'foo')
         for i in range(0, len(fakes)):
@@ -1001,7 +1001,7 @@ class _TestInstanceListObject(object):
         self.mox.StubOutWithMock(db, 'instance_fault_get_by_instance_uuids')
         db.instance_get_all_by_host(self.context, 'host',
                                     columns_to_join=[],
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn(fake_insts)
         db.instance_fault_get_by_instance_uuids(
             self.context, [x['uuid'] for x in fake_insts]
@@ -1009,7 +1009,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         instances = instance.InstanceList.get_by_host(self.context, 'host',
                                                       expected_attrs=['fault'],
-                                                      use_slave=False)
+                                                      use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault.iteritems()))

--- a/nova/tests/objects/test_migration.py
+++ b/nova/tests/objects/test_migration.py
@@ -116,7 +116,7 @@ class _TestMigrationObject(object):
         db.instance_get_by_uuid(ctxt, fake_migration['instance_uuid'],
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(fake_inst)
         mig = migration.Migration._from_db_object(ctxt,
                                                   migration.Migration(),
@@ -133,11 +133,11 @@ class _TestMigrationObject(object):
             db, 'migration_get_unconfirmed_by_dest_compute')
         db.migration_get_unconfirmed_by_dest_compute(
             ctxt, 'window', 'foo',
-            use_slave=False).AndReturn(db_migrations)
+            use_subordinate=False).AndReturn(db_migrations)
         self.mox.ReplayAll()
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/nova/tests/objects/test_service.py
+++ b/nova/tests/objects/test_service.py
@@ -34,7 +34,7 @@ fake_service = {
     'disabled_reason': None,
     }
 
-OPTIONAL = ['availability_zone', 'compute_node']
+OPTIONAL = ['availability_zone', 'compute_node', 'geo_tag']
 
 
 class _TestServiceObject(object):

--- a/nova/tests/scheduler/test_host_filters.py
+++ b/nova/tests/scheduler/test_host_filters.py
@@ -1858,10 +1858,12 @@ class HostFiltersTestCase(test.NoDBTestCase):
         filter_properties = {'context': self.context.elevated()}
         self.assertTrue(filt_cls.host_passes(host, filter_properties))
 
-    @mock.patch('nova.objects.geo_tags.GeoTag.get_by_node_name')
-    def test_geo_tags_filter_valid_invalid_rack(self, geo_tag_mock):
+    #@mock.patch('nova.objects.geo_tags.GeoTag.get_by_node_name')
+    def _test_geo_tags_filter(self, gtag, wanted,
+                              host_passes=False):
+        geo_tag_mock = mock.Mock('nova.objects.geo_tags.GeoTag.get_by_node_name')
         geo_tag_mock.return_value = {'valid_invalid': 'Valid',
-                                     'loc_or_error_msg': '1-3-2'}
+                                     'loc_or_error_msg': gtag}
 
         filt_cls = self.class_map['GeoTagsFilter']()
         host = fakes.FakeHostState('host1', 'node1', {})
@@ -1869,25 +1871,24 @@ class HostFiltersTestCase(test.NoDBTestCase):
                                          params={'host': 'host2'})
         instance_uuid = instance.uuid
 
+        wanted_tags = '{"rack_location": "%s"}' % wanted
         filter_properties = {'context': self.context.elevated(),
                              'scheduler_hints': {
-                                'geo_tags': '{"rack_location": "1-3-4"}'}}
+                                  'geo_tags': wanted_tags}}
+        if host_passes:
+            self.assertTrue(filt_cls.host_passes(host, filter_properties))
+        else:
+            self.assertFalse(filt_cls.host_passes(host, filter_properties))
 
-        self.assertFalse(filt_cls.host_passes(host, filter_properties))
+    def test_geo_tags_filter_valid_rack(self):
+        ok_locations = ['1-2-3-4-5', '1-2-3-4', '1-2-3-4-',
+                        '1-2-3', '1-2', '1-', '1']
+        for x in ok_locations:
+            self._test_geo_tags_filter('1-2-3-4-5', x, True)
 
-    @mock.patch('nova.objects.geo_tags.GeoTag.get_by_node_name')
-    def test_geo_tags_filter_valid_rack(self, geo_tag_mock):
-        geo_tag_mock.return_value = {'valid_invalid': 'Valid',
-                                     'loc_or_error_msg': '1-3-4'}
+    def test_geo_tags_filter_invalid_rack(self):
+        ok_locations = ['1-2-3-4-3', '1-2-3-2', '1-2-3-1-',
+                        '1-5-3', '3-2', '2-', '2']
+        for x in ok_locations:
+            self._test_geo_tags_filter('1-2-3-4-5', x, True)
 
-        filt_cls = self.class_map['GeoTagsFilter']()
-        host = fakes.FakeHostState('host1', 'node1', {})
-        instance = fakes.FakeInstance(context=self.context,
-                                         params={'host': 'host2'})
-        instance_uuid = instance.uuid
-
-        filter_properties = {'context': self.context.elevated(),
-                             'scheduler_hints': {
-                                'geo_tags': '{"rack_location": "1-3-4"}'}}
-
-        self.assertTrue(filt_cls.host_passes(host, filter_properties))

--- a/nova/tests/test_metadata.py
+++ b/nova/tests/test_metadata.py
@@ -201,7 +201,7 @@ class MetadataTestCase(test.TestCase):
                          'default_ephemeral_device': None,
                          'default_swap_device': None})
 
-        def fake_bdm_get(ctxt, uuid, use_slave=False):
+        def fake_bdm_get(ctxt, uuid, use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                     {'volume_id': 87654321,
                      'snapshot_id': None,

--- a/nova/tests/virt/libvirt/test_libvirt.py
+++ b/nova/tests/virt/libvirt/test_libvirt.py
@@ -4974,7 +4974,7 @@ class LibvirtConnTestCase(test.TestCase):
         db.instance_get_by_uuid(mox.IgnoreArg(), mox.IgnoreArg(),
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(instance)
         self.mox.StubOutWithMock(driver, "block_device_info_get_mapping")
         driver.block_device_info_get_mapping(vol
@@ -5081,7 +5081,7 @@ class LibvirtConnTestCase(test.TestCase):
         db.instance_get_by_uuid(mox.IgnoreArg(), mox.IgnoreArg(),
                                 columns_to_join=['info_cache',
                                                  'security_groups'],
-                                use_slave=False
+                                use_subordinate=False
                                 ).AndReturn(instance)
         os.path.exists(mox.IgnoreArg()).AndReturn(False)
         os.path.exists(mox.IgnoreArg()).AndReturn(True)

--- a/nova/tests/virt/xenapi/test_xenapi.py
+++ b/nova/tests/virt/xenapi/test_xenapi.py
@@ -1444,7 +1444,7 @@ class XenAPIVMTestCase(stubs.XenAPITestBase):
         fake_inst2 = fake_instance.fake_db_instance(id=456)
         db.instance_get_all_by_host(self.context, fake_inst['host'],
                                     columns_to_join=None,
-                                    use_slave=False
+                                    use_subordinate=False
                                     ).AndReturn([fake_inst, fake_inst2])
         self.mox.ReplayAll()
         expected_name = CONF.instance_name_template % fake_inst['id']
@@ -1461,7 +1461,7 @@ class XenAPIVMTestCase(stubs.XenAPITestBase):
         self.stubs.Set(db, "aggregate_get_by_host",
                        fake_aggregate_get_by_host)
 
-        self.stubs.Set(self.conn._session, "is_slave", True)
+        self.stubs.Set(self.conn._session, "is_subordinate", True)
 
         self.assertRaises(test.TestingException,
                 self.conn._session._get_host_uuid)
@@ -2889,7 +2889,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                   pool_states.POOL_FLAG: 'XenAPI'}}
         self.aggr = db.aggregate_create(self.context, values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -2899,18 +2899,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_add_to_aggregate, calls)
 
@@ -2919,18 +2919,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_remove_from_aggregate, calls)
 
@@ -2946,11 +2946,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result['metadetails']))
 
-    def test_join_slave(self):
-        # Ensure join_slave gets called when the request gets to master.
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        # Ensure join_subordinate gets called when the request gets to main.
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -2960,7 +2960,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -3000,19 +3000,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        # Ensure eject slave gets called.
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        # Ensure eject subordinate gets called.
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         # Ensure metadata are cleared after removal.
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -3027,8 +3027,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result['metadetails']))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3136,7 +3136,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=jsonutils.to_primitive(self.aggr),
-                          slave_info=None)
+                          subordinate_info=None)
         excepted = db.aggregate_get(self.context, self.aggr['id'])
         self.assertEqual(excepted['metadetails'][pool_states.KEY],
                 pool_states.ERROR)
@@ -3148,16 +3148,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param,
-                              host, slave_info):
+                              host, subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3172,10 +3172,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3189,32 +3189,32 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: {},
             pool_states.KEY: {}
             }
         }
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
+            (subordinate.compute_rpcapi.add_aggregate_host,
             "CONTEXT", jsonutils.to_primitive(self.fake_aggregate),
-            "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/nova/virt/xenapi/client/session.py
+++ b/nova/virt/xenapi/client/session.py
@@ -79,7 +79,7 @@ class XenAPISession(object):
         import XenAPI
         self.XenAPI = XenAPI
         self._sessions = queue.Queue()
-        self.is_slave = False
+        self.is_subordinate = False
         exception = self.XenAPI.Failure(_("Unable to log in to XenAPI "
                                           "(is the Dom0 disk full?)"))
         url = self._create_first_session(url, user, pw, exception)
@@ -109,13 +109,13 @@ class XenAPISession(object):
             with timeout.Timeout(CONF.xenserver.login_timeout, exception):
                 session.login_with_password(user, pw)
         except self.XenAPI.Failure as e:
-            # if user and pw of the master are different, we're doomed!
+            # if user and pw of the main are different, we're doomed!
             if e.details[0] == 'HOST_IS_SLAVE':
-                master = e.details[1]
-                url = pool.swap_xapi_host(url, master)
+                main = e.details[1]
+                url = pool.swap_xapi_host(url, main)
                 session = self.XenAPI.Session(url)
                 session.login_with_password(user, pw)
-                self.is_slave = True
+                self.is_subordinate = True
             else:
                 raise
         self._sessions.put(session)
@@ -129,7 +129,7 @@ class XenAPISession(object):
             self._sessions.put(session)
 
     def _get_host_uuid(self):
-        if self.is_slave:
+        if self.is_subordinate:
             aggr = aggregate_obj.AggregateList.get_by_host(
                 context.get_admin_context(),
                 CONF.host, key=pool_states.POOL_FLAG)[0]

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -114,7 +114,7 @@ def create_host(name_label, hostname='fake_name', address='fake_addr'):
     # Create a pool if we don't have one already
     if len(_db_content['pool']) == 0:
         pool_ref = _create_pool('')
-        _db_content['pool'][pool_ref]['master'] = host_ref
+        _db_content['pool'][pool_ref]['main'] = host_ref
         _db_content['pool'][pool_ref]['default-SR'] = host_default_sr_ref
         _db_content['pool'][pool_ref]['suspend-image-SR'] = host_default_sr_ref
 
@@ -833,7 +833,7 @@ class SessionBase(object):
             return self._session
         elif name == 'xenapi':
             return _Dispatcher(self.xenapi_request, None)
-        elif name.startswith('login') or name.startswith('slave_local'):
+        elif name.startswith('login') or name.startswith('subordinate_local'):
             return lambda *params: self._login(name, params)
         elif name.startswith('Async'):
             return lambda *params: self._async(name, params)

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -68,7 +68,7 @@ class ResourcePool(object):
                             'during operation on %(host)s'),
                           {'aggregate_id': aggregate['id'], 'host': host})
 
-    def add_to_aggregate(self, context, aggregate, host, slave_info=None):
+    def add_to_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Add a compute host to an aggregate."""
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
@@ -86,38 +86,38 @@ class ResourcePool(object):
         if (aggregate['metadata'][pool_states.KEY] == pool_states.CREATED):
             aggregate.update_metadata({pool_states.KEY: pool_states.CHANGING})
         if len(aggregate['hosts']) == 1:
-            # this is the first host of the pool -> make it master
+            # this is the first host of the pool -> make it main
             self._init_pool(aggregate['id'], aggregate['name'])
-            # save metadata so that we can find the master again
-            metadata = {'master_compute': host,
+            # save metadata so that we can find the main again
+            metadata = {'main_compute': host,
                         host: self._host_uuid,
                         pool_states.KEY: pool_states.ACTIVE}
             aggregate.update_metadata(metadata)
         else:
             # the pool is already up and running, we need to figure out
             # whether we can serve the request from this host or not.
-            master_compute = aggregate['metadata']['master_compute']
-            if master_compute == CONF.host and master_compute != host:
-                # this is the master ->  do a pool-join
-                # To this aim, nova compute on the slave has to go down.
+            main_compute = aggregate['metadata']['main_compute']
+            if main_compute == CONF.host and main_compute != host:
+                # this is the main ->  do a pool-join
+                # To this aim, nova compute on the subordinate has to go down.
                 # NOTE: it is assumed that ONLY nova compute is running now
-                self._join_slave(aggregate['id'], host,
-                                 slave_info.get('compute_uuid'),
-                                 slave_info.get('url'), slave_info.get('user'),
-                                 slave_info.get('passwd'))
-                metadata = {host: slave_info.get('xenhost_uuid'), }
+                self._join_subordinate(aggregate['id'], host,
+                                 subordinate_info.get('compute_uuid'),
+                                 subordinate_info.get('url'), subordinate_info.get('user'),
+                                 subordinate_info.get('passwd'))
+                metadata = {host: subordinate_info.get('xenhost_uuid'), }
                 aggregate.update_metadata(metadata)
-            elif master_compute and master_compute != host:
-                # send rpc cast to master, asking to add the following
+            elif main_compute and main_compute != host:
+                # send rpc cast to main, asking to add the following
                 # host with specified credentials.
-                slave_info = self._create_slave_info()
+                subordinate_info = self._create_subordinate_info()
 
                 self.compute_rpcapi.add_aggregate_host(
-                    context, aggregate, host, master_compute, slave_info)
+                    context, aggregate, host, main_compute, subordinate_info)
 
-    def remove_from_aggregate(self, context, aggregate, host, slave_info=None):
+    def remove_from_aggregate(self, context, aggregate, host, subordinate_info=None):
         """Remove a compute host from an aggregate."""
-        slave_info = slave_info or dict()
+        subordinate_info = subordinate_info or dict()
         if not pool_states.is_hv_pool(aggregate['metadata']):
             return
 
@@ -130,19 +130,19 @@ class ResourcePool(object):
                     aggregate_id=aggregate['id'],
                     reason=invalid[aggregate['metadata'][pool_states.KEY]])
 
-        master_compute = aggregate['metadata']['master_compute']
-        if master_compute == CONF.host and master_compute != host:
-            # this is the master -> instruct it to eject a host from the pool
+        main_compute = aggregate['metadata']['main_compute']
+        if main_compute == CONF.host and main_compute != host:
+            # this is the main -> instruct it to eject a host from the pool
             host_uuid = aggregate['metadata'][host]
-            self._eject_slave(aggregate['id'],
-                              slave_info.get('compute_uuid'), host_uuid)
+            self._eject_subordinate(aggregate['id'],
+                              subordinate_info.get('compute_uuid'), host_uuid)
             aggregate.update_metadata({host: None})
-        elif master_compute == host:
-            # Remove master from its own pool -> destroy pool only if the
-            # master is on its own, otherwise raise fault. Destroying a
-            # pool made only by master is fictional
+        elif main_compute == host:
+            # Remove main from its own pool -> destroy pool only if the
+            # main is on its own, otherwise raise fault. Destroying a
+            # pool made only by main is fictional
             if len(aggregate['hosts']) > 1:
-                # NOTE: this could be avoided by doing a master
+                # NOTE: this could be avoided by doing a main
                 # re-election, but this is simpler for now.
                 raise exception.InvalidAggregateAction(
                                     aggregate_id=aggregate['id'],
@@ -151,32 +151,32 @@ class ResourcePool(object):
                                              'from the pool; pool not empty')
                                              % host)
             self._clear_pool(aggregate['id'])
-            aggregate.update_metadata({'master_compute': None, host: None})
-        elif master_compute and master_compute != host:
-            # A master exists -> forward pool-eject request to master
-            slave_info = self._create_slave_info()
+            aggregate.update_metadata({'main_compute': None, host: None})
+        elif main_compute and main_compute != host:
+            # A main exists -> forward pool-eject request to main
+            subordinate_info = self._create_subordinate_info()
 
             self.compute_rpcapi.remove_aggregate_host(
-                context, aggregate['id'], host, master_compute, slave_info)
+                context, aggregate['id'], host, main_compute, subordinate_info)
         else:
             # this shouldn't have happened
             raise exception.AggregateError(aggregate_id=aggregate['id'],
                                            action='remove_from_aggregate',
                                            reason=_('Unable to eject %s '
-                                           'from the pool; No master found')
+                                           'from the pool; No main found')
                                            % host)
 
-    def _join_slave(self, aggregate_id, host, compute_uuid, url, user, passwd):
-        """Joins a slave into a XenServer resource pool."""
+    def _join_subordinate(self, aggregate_id, host, compute_uuid, url, user, passwd):
+        """Joins a subordinate into a XenServer resource pool."""
         try:
             args = {'compute_uuid': compute_uuid,
                     'url': url,
                     'user': user,
                     'password': passwd,
                     'force': jsonutils.dumps(CONF.xenserver.use_join_force),
-                    'master_addr': self._host_addr,
-                    'master_user': CONF.xenserver.connection_username,
-                    'master_pass': CONF.xenserver.connection_password, }
+                    'main_addr': self._host_addr,
+                    'main_user': CONF.xenserver.connection_username,
+                    'main_pass': CONF.xenserver.connection_password, }
             self._session.call_plugin('xenhost', 'host_join', args)
         except self._session.XenAPI.Failure as e:
             LOG.error(_("Pool-Join failed: %s"), e)
@@ -185,8 +185,8 @@ class ResourcePool(object):
                                            reason=_('Unable to join %s '
                                                   'in the pool') % host)
 
-    def _eject_slave(self, aggregate_id, compute_uuid, host_uuid):
-        """Eject a slave from a XenServer resource pool."""
+    def _eject_subordinate(self, aggregate_id, compute_uuid, host_uuid):
+        """Eject a subordinate from a XenServer resource pool."""
         try:
             # shutdown nova-compute; if there are other VMs running, e.g.
             # guest instances, the eject will fail. That's a precaution
@@ -225,7 +225,7 @@ class ResourcePool(object):
                                            action='remove_from_aggregate',
                                            reason=str(e.details))
 
-    def _create_slave_info(self):
+    def _create_subordinate_info(self):
         """XenServer specific info needed to join the hypervisor pool."""
         # replace the address from the xenapi connection url
         # because this might be 169.254.0.1, i.e. xenapi

--- a/nova/virt/xenapi/pool_states.py
+++ b/nova/virt/xenapi/pool_states.py
@@ -25,7 +25,7 @@ cases.
 A 'created' pool becomes 'changing' during the first request of
 adding a host. During a 'changing' status no other requests will be accepted;
 this is to allow the hypervisor layer to instantiate the underlying pool
-without any potential race condition that may incur in master/slave-based
+without any potential race condition that may incur in main/subordinate-based
 configurations. The pool goes into the 'active' state when the underlying
 pool has been correctly instantiated.
 All other operations (e.g. add/remove hosts) that succeed will keep the

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -26,7 +26,7 @@ The schema versions are specified by providing a git ref (a branch name or
 commit hash) and a SQLAlchemy-Migrate version number:
 Run like:
 
-    ./tools/db/schema_diff.py mysql master:latest my_branch:82
+    ./tools/db/schema_diff.py mysql main:latest my_branch:82
 """
 
 from __future__ import print_function
@@ -216,12 +216,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_type, orig_branch, orig_version, new_branch, new_version
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.